### PR TITLE
chore(ci): restrict workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,14 +8,16 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Monday 6am UTC
 
-permissions:
-  security-events: write
+permissions: read-all
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    permissions:
+      security-events: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,10 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: read-all
 
 concurrency:
   group: pages
@@ -17,6 +14,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,7 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  id-token: write
+permissions: read-all
 
 jobs:
   release:
@@ -15,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.repository == 'danfry1/reflow-ts'
+
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Add top-level `permissions: read-all` to CI workflow (was missing entirely)
- Set top-level `permissions: read-all` on all other workflows
- Move write permissions to job-level declarations only
- Satisfies the OpenSSF Scorecard **Token-Permissions** check

## Test plan

- [ ] CI passes
- [ ] CodeQL workflow still has `security-events: write` at job level
- [ ] Pages deploy still has `pages: write` and `id-token: write` at job level
- [ ] Release workflow still has `contents: write` and `id-token: write` at job level