### PR TITLE
fix(ci): ignore node10 resolution failures in release type check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check package exports
         run: |
           npm pack --pack-destination /tmp
-          npx --yes @arethetypeswrong/cli /tmp/reflow-ts-*.tgz --ignore-rules cjs-resolves-to-esm
+          npx --yes @arethetypeswrong/cli /tmp/reflow-ts-*.tgz --ignore-rules cjs-resolves-to-esm no-resolution
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Add `no-resolution` to the ignored rules for `@arethetypeswrong/cli` in the release workflow
- The `node10` module resolution does not support `exports` subpaths, which is expected for an ESM-only package

## Test plan

- [x] Release workflow passes the type check step