### PR TITLE
feat: .parallel() — concurrent step groups (closes #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 *.db-wal
 *.db-shm
 .DS_Store
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
-## 0.3.0
+## 0.4.0
 
 ### Added
 
 - **`.parallel({ ... })`** — concurrent step groups. Run independent steps at the same time and receive a typed merged record as `prev` in the next step. Each branch supports per-branch retry and `timeoutMs`. Fail-fast on first branch failure (siblings receive `signal.abort()`) and per-branch crash recovery — completed branches are skipped on resume, so side effects do not fire twice. `onRunFailed` and `onFailure` report the branch that actually caused the failure, not a sibling aborted by propagation. ([#20](https://github.com/danfry1/reflow-ts/issues/20) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
-- **`onRunStart` / `onStepStart` hooks** — new lifecycle hooks for observability and timing; `onRunStart` fires when a run begins executing, `onStepStart` fires before each step runs ([#12](https://github.com/danfry1/reflow-ts/issues/12) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
 
 ### Changed
 
 - `Workflow` exposes a new `executionUnits` array (replacing the internal `steps` list) so the engine can distinguish sequential steps from parallel groups. Sequential `.step()` workflows remain fully type- and behavior-compatible.
 - New `ParallelCompleteError` is exported and thrown when `complete()` is called inside a parallel branch (early completion is only meaningful in sequential context).
+
+## 0.3.0
+
+### Added
+
+- **`onRunStart` / `onStepStart` hooks** — new lifecycle hooks for observability and timing; `onRunStart` fires when a run begins executing, `onStepStart` fires before each step runs ([#12](https://github.com/danfry1/reflow-ts/issues/12) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
 
 ## 0.2.0 — 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Added
 
+- **`.parallel({ ... })`** — concurrent step groups. Run independent steps at the same time and receive a typed merged record as `prev` in the next step. Each branch supports per-branch retry and `timeoutMs`. Fail-fast on first branch failure (siblings receive `signal.abort()`) and per-branch crash recovery — completed branches are skipped on resume, so side effects do not fire twice. `onRunFailed` and `onFailure` report the branch that actually caused the failure, not a sibling aborted by propagation. ([#20](https://github.com/danfry1/reflow-ts/issues/20) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
 - **`onRunStart` / `onStepStart` hooks** — new lifecycle hooks for observability and timing; `onRunStart` fires when a run begins executing, `onStepStart` fires before each step runs ([#12](https://github.com/danfry1/reflow-ts/issues/12) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
+
+### Changed
+
+- `Workflow` exposes a new `executionUnits` array (replacing the internal `steps` list) so the engine can distinguish sequential steps from parallel groups. Sequential `.step()` workflows remain fully type- and behavior-compatible.
+- New `ParallelCompleteError` is exported and thrown when `complete()` is called inside a parallel branch (early completion is only meaningful in sequential context).
 
 ## 0.2.0 — 2026-03-20
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,44 @@ const workflow = createWorkflow({ name: 'conditional', input: schema })
 
 The optional value passed to `complete()` is persisted as the step result and visible via `getRunStatus()`. Early completion is crash-safe — if the engine crashes after saving the step but before marking the run completed, recovery will detect the early-complete marker and finish the run without re-executing later steps.
 
+### Parallel Steps
+
+Run multiple independent steps concurrently with `.parallel()`. Each branch is a named handler that runs at the same time as its siblings; the next step receives a merged record of all branch outputs as `prev`:
+
+```typescript
+const pipeline = createWorkflow({ name: 'pipeline', input: z.object({ url: z.string() }) })
+  .step('fetch', async ({ input }) => ({ body: await fetchPage(input.url) }))
+  .parallel({
+    summary: async ({ prev }) => ({ text: await summarize(prev.body) }),
+    keywords: async ({ prev }) => ({ tags: await extractKeywords(prev.body) }),
+    images: async ({ prev }) => ({ urls: await extractImages(prev.body) }),
+  })
+  .step('save', async ({ prev }) => {
+    // prev is fully typed: { summary: { text }, keywords: { tags }, images: { urls } }
+    await save(prev.summary.text, prev.keywords.tags, prev.images.urls)
+  })
+```
+
+Branches accept the same `{ retry, timeoutMs, handler }` config form as `.step()`, so each branch can have its own retry and timeout policy:
+
+```typescript
+.parallel({
+  flaky: {
+    retry: { maxAttempts: 3, backoff: 'exponential', initialDelayMs: 100 },
+    handler: async () => await callFlakyApi(),
+  },
+  stable: async () => await callStableApi(),
+})
+```
+
+**Semantics:**
+
+- **Fail-fast.** When one branch fails (after exhausting its own retries), siblings receive `signal.abort()` and the run is marked `failed`. `onRunFailed` and `onFailure` report the branch that actually caused the failure, not a sibling aborted by the abort propagation.
+- **Crash recovery is per-branch.** If the engine crashes after some branches have persisted their results, recovery skips those branches and only re-runs the missing ones. Side effects in already-completed branches do not fire twice.
+- **No `complete()` inside a branch.** Calling `complete()` from a parallel branch throws `ParallelCompleteError` — early completion is only meaningful in sequential context.
+- **Each branch must be idempotent.** Like sequential steps, a branch may run multiple times across crash recoveries before its result is persisted.
+- **`steps` is a frozen snapshot.** All sibling branches see the same `steps` view taken before the group started; they cannot observe each other's outputs mid-flight.
+
 ### Run Status
 
 Query the status of any run and its step results:
@@ -612,6 +650,23 @@ Adds a step to the workflow. Accepts either a handler function or a config objec
 | `backoff` | `'linear' \| 'exponential'` | Backoff strategy between retries |
 | `initialDelayMs` | `number` | Base delay in milliseconds (default: 1000) |
 | `timeoutMs` | `number` | Timeout per attempt. Step-level `timeoutMs` takes precedence |
+
+### `workflow.parallel(branches)`
+
+Adds a group of concurrent steps. `branches` is a record of `{ branchName: handler | config }`. All branches run at the same time; the next step's `prev` is `{ [branchName]: output }` (merged across all branches).
+
+```typescript
+.parallel({
+  a: async ({ prev }) => ({ x: prev.value * 2 }),
+  b: {
+    retry: { maxAttempts: 3, backoff: 'linear' },
+    timeoutMs: 5000,
+    handler: async () => await someCall(),
+  },
+})
+```
+
+Branch names share the same namespace as `.step()` names — duplicate names across `.step()` and `.parallel()` throw `DuplicateStepError`.
 
 ### `workflow.onFailure(handler)`
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -51,6 +51,7 @@
             <a href="#retry">Retry</a>
             <a href="#failure-handling">Failure Handling</a>
             <a href="#error-handling">Error Handling</a>
+            <a href="#parallel-steps">Parallel Steps</a>
             <a href="#crash-recovery">Crash Recovery</a>
             <a href="#concurrency">Concurrency</a>
             <a href="#cancellation">Cancellation</a>
@@ -68,6 +69,7 @@
             <h4>API Reference</h4>
             <a href="#api-createworkflow">createWorkflow</a>
             <a href="#api-step">workflow.step</a>
+            <a href="#api-parallel">workflow.parallel</a>
             <a href="#api-onfailure">workflow.onFailure</a>
             <a href="#api-createengine">createEngine</a>
             <a href="#api-engine-start">engine.start</a>
@@ -404,6 +406,42 @@ engine.enqueue('nonexistent', {})                                 // Type error<
 
           <p>The optional value passed to <code>complete()</code> is persisted as the step result and visible via <code>getRunStatus()</code>. Early completion is crash-safe — if the engine crashes after saving the step but before marking the run completed, recovery detects the marker and finishes the run without re-executing later steps.</p>
 
+          <!-- Parallel Steps -->
+          <h2 id="parallel-steps">Parallel Steps</h2>
+
+          <p>Run multiple independent steps concurrently with <code>.parallel()</code>. Each branch is a named handler that runs at the same time as its siblings; the next step receives a merged record of all branch outputs as <code>prev</code>:</p>
+
+          <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false" data-compact="true"><code>const pipeline = createWorkflow({ name: 'pipeline', input: z.object({ url: z.string() }) })
+  .step('fetch', async ({ input }) => ({ body: await fetchPage(input.url) }))
+  .parallel({
+    summary:  async ({ prev }) => ({ text: await summarize(prev.body) }),
+    keywords: async ({ prev }) => ({ tags: await extractKeywords(prev.body) }),
+    images:   async ({ prev }) => ({ urls: await extractImages(prev.body) }),
+  })
+  .step('save', async ({ prev }) => {
+    // prev is fully typed: { summary: { text }, keywords: { tags }, images: { urls } }
+    await save(prev.summary.text, prev.keywords.tags, prev.images.urls)
+  })</code></pre>
+
+          <p>Branches accept the same <code>{ retry, timeoutMs, handler }</code> config as <code>.step()</code>, so each branch can have its own retry and timeout policy:</p>
+
+          <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false" data-compact="true"><code>.parallel({
+  flaky: {
+    retry: { maxAttempts: 3, backoff: 'exponential', initialDelayMs: 100 },
+    handler: async () => await callFlakyApi(),
+  },
+  stable: async () => await callStableApi(),
+})</code></pre>
+
+          <h3>Semantics</h3>
+          <ul>
+            <li><strong>Fail-fast.</strong> When a branch fails (after exhausting its own retries), siblings receive <code>signal.abort()</code> and the run is marked <code>failed</code>. <code>onRunFailed</code> and <code>onFailure</code> report the branch that actually caused the failure, not a sibling aborted by the propagation.</li>
+            <li><strong>Crash recovery is per-branch.</strong> If the engine crashes after some branches have persisted their results, recovery skips those branches and only re-runs the missing ones. Side effects in already-completed branches do not fire twice.</li>
+            <li><strong>No <code>complete()</code> inside a branch.</strong> Calling <code>complete()</code> from a parallel branch throws <code>ParallelCompleteError</code> — early completion is only meaningful in a sequential context.</li>
+            <li><strong>Each branch must be idempotent.</strong> Like sequential steps, a branch may run more than once across crash recoveries before its result is persisted.</li>
+            <li><strong><code>steps</code> is a frozen snapshot.</strong> All sibling branches see the same <code>steps</code> view taken before the group started; they cannot observe each other's outputs mid-flight.</li>
+          </ul>
+
           <!-- Crash Recovery -->
           <h2 id="crash-recovery">Crash Recovery</h2>
 
@@ -678,7 +716,7 @@ workflow.step('x', async ({ prev }) => {
                   <span class="api-param-desc">Any Standard Schema-compatible schema (Zod, Valibot, ArkType, etc.)</span>
                 </div>
               </div>
-              <div class="api-returns">Returns <code>Workflow</code> with <code>.step()</code>, <code>.onFailure()</code>, and <code>.parseInput()</code> methods.</div>
+              <div class="api-returns">Returns <code>Workflow</code> with <code>.step()</code>, <code>.parallel()</code>, <code>.onFailure()</code>, and <code>.parseInput()</code> methods.</div>
             </div>
 
             <div class="api-card" id="api-step">
@@ -770,6 +808,47 @@ workflow.step('x', async ({ prev }) => {
                 </div>
               </div>
               <div class="api-returns">Returns a new <code>Workflow</code> with the step appended. The builder is immutable.</div>
+            </div>
+
+            <div class="api-card" id="api-parallel">
+              <div class="api-header">
+                <span class="api-badge">method</span>
+                <h3>workflow.parallel(branches)</h3>
+              </div>
+              <p>Adds a group of concurrent steps. <code>branches</code> is a record of <code>{ branchName: handler | config }</code>. All branches run at the same time; the next step's <code>prev</code> is <code>{ [branchName]: output }</code> merged across all branches.</p>
+              <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false" data-compact="true"><code>.parallel({
+  a: async ({ prev }) =&gt; ({ x: prev.value * 2 }),
+  b: {
+    retry: { maxAttempts: 3, backoff: 'linear' },
+    timeoutMs: 5000,
+    handler: async () =&gt; await someCall(),
+  },
+})</code></pre>
+              <div class="api-params">
+                <p class="api-params-label">Branch context</p>
+                <div class="api-param">
+                  <span class="api-param-name">input</span>
+                  <span class="api-param-type">TInput</span>
+                  <span class="api-param-desc">The validated workflow input (same for every branch)</span>
+                </div>
+                <div class="api-param">
+                  <span class="api-param-name">prev</span>
+                  <span class="api-param-type">TPrev</span>
+                  <span class="api-param-desc">Output of the step before the group (same for every sibling)</span>
+                </div>
+                <div class="api-param">
+                  <span class="api-param-name">steps</span>
+                  <span class="api-param-type">TStepsSoFar</span>
+                  <span class="api-param-desc">Frozen snapshot of all step results before the group started</span>
+                </div>
+                <div class="api-param">
+                  <span class="api-param-name">signal</span>
+                  <span class="api-param-type">AbortSignal</span>
+                  <span class="api-param-desc">Aborted on cancellation, lease loss, branch timeout, or a sibling failure</span>
+                </div>
+              </div>
+              <p>Branch names share the same namespace as <code>.step()</code> names — duplicate names across <code>.step()</code> and <code>.parallel()</code> throw <code>DuplicateStepError</code>. Calling <code>complete()</code> inside a branch throws <code>ParallelCompleteError</code>.</p>
+              <div class="api-returns">Returns a new <code>Workflow</code> whose next step receives <code>prev: { [branchName]: branchOutput }</code>.</div>
             </div>
 
             <div class="api-card" id="api-onfailure">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -228,6 +228,43 @@ Clean up with onFailure - compensation after the workflow has failed (saga patte
 
 Most workflows combine all three: try/catch for expected errors, retry for transient failures, onFailure for rollback.
 
+### Parallel Steps
+
+Run multiple independent steps concurrently with .parallel(). Each branch is a named handler that runs at the same time as its siblings; the next step receives a merged record of all branch outputs as prev:
+
+```typescript
+const pipeline = createWorkflow({ name: 'pipeline', input: z.object({ url: z.string() }) })
+  .step('fetch', async ({ input }) => ({ body: await fetchPage(input.url) }))
+  .parallel({
+    summary:  async ({ prev }) => ({ text: await summarize(prev.body) }),
+    keywords: async ({ prev }) => ({ tags: await extractKeywords(prev.body) }),
+    images:   async ({ prev }) => ({ urls: await extractImages(prev.body) }),
+  })
+  .step('save', async ({ prev }) => {
+    // prev: { summary: { text }, keywords: { tags }, images: { urls } }
+    await save(prev.summary.text, prev.keywords.tags, prev.images.urls)
+  })
+```
+
+Branches accept the same { retry, timeoutMs, handler } config as .step():
+
+```typescript
+.parallel({
+  flaky: {
+    retry: { maxAttempts: 3, backoff: 'exponential', initialDelayMs: 100 },
+    handler: async () => await callFlakyApi(),
+  },
+  stable: async () => await callStableApi(),
+})
+```
+
+Semantics:
+- Fail-fast: when a branch fails (after exhausting its own retries), siblings receive signal.abort() and the run is marked failed. onRunFailed and onFailure report the branch that actually caused the failure, not a sibling aborted by the propagation.
+- Crash recovery is per-branch: if some branches persisted their results before a crash, only the missing ones re-run. Side effects in completed branches do not fire twice.
+- No complete() inside a branch: throws ParallelCompleteError.
+- Each branch must be idempotent.
+- steps is a frozen snapshot taken before the group started; siblings cannot observe each other's outputs mid-flight.
+
 ### Crash Recovery
 
 Reflow automatically resumes workflows from the last completed step. If the process crashes after step 2 of 5, a later engine instance reclaims the stale run after runLeaseDurationMs and continues at step 3. Completed steps are never re-executed.
@@ -357,7 +394,7 @@ Reflow tracks types through the entire workflow chain:
 | config.name | string            | Unique workflow name (becomes a literal type)        |
 | config.input| StandardSchemaV1  | Any Standard Schema-compatible schema                |
 
-Returns a Workflow with .step(), .onFailure(), and .parseInput() methods.
+Returns a Workflow with .step(), .parallel(), .onFailure(), and .parseInput() methods.
 
 ### workflow.step(name, handler | config)
 
@@ -377,6 +414,23 @@ RetryConfig:
 | backoff       | 'linear' | 'exponential'  | Backoff strategy                     |
 | initialDelayMs| number                    | Base delay ms (default: 1000)        |
 | timeoutMs     | number                    | Timeout per attempt                  |
+
+### workflow.parallel(branches)
+
+Adds a group of concurrent steps. branches is a record of { branchName: handler | config }. All branches run at the same time; the next step's prev is { [branchName]: branchOutput } merged across all branches.
+
+```typescript
+.parallel({
+  a: async ({ prev }) => ({ x: prev.value * 2 }),
+  b: {
+    retry: { maxAttempts: 3, backoff: 'linear' },
+    timeoutMs: 5000,
+    handler: async () => await someCall(),
+  },
+})
+```
+
+Branch names share the same namespace as .step() names — duplicates throw DuplicateStepError. Calling complete() inside a branch throws ParallelCompleteError.
 
 ### workflow.onFailure(handler)
 

--- a/examples/4-parallel-enrichment.ts
+++ b/examples/4-parallel-enrichment.ts
@@ -1,0 +1,108 @@
+/**
+ * Example 4: Parallel Enrichment — Fan-out / Fan-in
+ *
+ * Scenario: You've just received a new user signup. Before letting them in,
+ * you want to enrich their profile from three independent services:
+ *   - A geo-IP service to determine their region
+ *   - A risk/fraud API to score their signup
+ *   - A CRM lookup to see if they already exist as a contact
+ *
+ * Each call is ~1 second. Done sequentially, that's 3+ seconds of latency.
+ * Done in parallel, it's just one. They share no data — perfect for `.parallel()`.
+ *
+ * Run: npx tsx examples/4-parallel-enrichment.ts
+ */
+import { createWorkflow, createEngine } from '../src/index'
+import { SQLiteStorage } from '../src/storage/sqlite-node'
+import { z } from 'zod'
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+// =====================================================
+// ❌ WITHOUT PARALLEL — Sequential calls accumulate latency
+// =====================================================
+//
+// async function enrich(userId: string, email: string, ip: string) {
+//   const region = await geoLookup(ip)       // 1s
+//   const risk = await scoreSignup(userId)   // 1s
+//   const crm = await findContact(email)     // 1s
+//   // 3s of wall-clock time for work that didn't need to be sequential.
+// }
+
+// =====================================================
+// ✅ WITH .parallel() — All three run concurrently
+// =====================================================
+
+const enrichmentWorkflow = createWorkflow({
+  name: 'enrich-signup',
+  input: z.object({
+    userId: z.string(),
+    email: z.string(),
+    ip: z.string(),
+  }),
+})
+  .step('record-signup', async ({ input }) => {
+    console.log(`  Recording signup for ${input.email}...`)
+    await sleep(200)
+    return { signupId: `signup_${input.userId}_${Date.now()}` }
+  })
+  .parallel({
+    geo: async ({ input }) => {
+      console.log(`  [geo] Looking up region for ${input.ip}...`)
+      await sleep(1000)
+      console.log(`  [geo] ✓ Done`)
+      return { region: 'EU-West', country: 'NL' }
+    },
+    risk: {
+      // Risk scoring is the flakiest of the three — retry on transient errors.
+      retry: { maxAttempts: 3, backoff: 'exponential', initialDelayMs: 200 },
+      timeoutMs: 3000,
+      handler: async ({ input }) => {
+        console.log(`  [risk] Scoring ${input.userId}...`)
+        await sleep(1000)
+        console.log(`  [risk] ✓ Done`)
+        return { score: 0.12, tier: 'low' as const }
+      },
+    },
+    crm: async ({ input }) => {
+      console.log(`  [crm] Checking for existing contact ${input.email}...`)
+      await sleep(1000)
+      console.log(`  [crm] ✓ Done`)
+      return { exists: false, contactId: null }
+    },
+  })
+  .step('finalize', async ({ prev, input, steps }) => {
+    // `prev` is the merged record of all three branch outputs — fully typed.
+    console.log(`  Finalizing profile for ${input.email}:`)
+    console.log(`    region:  ${prev.geo.region} (${prev.geo.country})`)
+    console.log(`    risk:    ${prev.risk.score} (${prev.risk.tier})`)
+    console.log(`    crm:     ${prev.crm.exists ? prev.crm.contactId : 'new contact'}`)
+    console.log(`    signup:  ${steps['record-signup'].signupId}`)
+    return { ready: true }
+  })
+
+async function main() {
+  const storage = new SQLiteStorage('/tmp/reflow-parallel-example.db')
+  await storage.initialize()
+  const engine = createEngine({ storage, workflows: [enrichmentWorkflow] })
+
+  const started = Date.now()
+  console.log('Enrich signup for alice@example.com...\n')
+
+  await engine.enqueue('enrich-signup', {
+    userId: 'u_alice',
+    email: 'alice@example.com',
+    ip: '203.0.113.42',
+  })
+  await engine.tick()
+
+  const elapsed = Date.now() - started
+  console.log(`\nDone in ${elapsed}ms (≈ 1.2s).`)
+  console.log('Sequential would have taken ≈ 3.2s.')
+
+  storage.close()
+}
+
+main()

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import {
   StepTimeoutError,
   RunCancelledError,
   LeaseExpiredError,
+  ParallelCompleteError,
 } from '../index'
 
 describe('public API', () => {
@@ -36,6 +37,7 @@ describe('public API', () => {
       StepTimeoutError,
       RunCancelledError,
       LeaseExpiredError,
+      ParallelCompleteError,
     ]
 
     for (const ErrorClass of errors) {
@@ -72,5 +74,10 @@ describe('public API', () => {
     const dupStepErr = new DuplicateStepError('my-wf', 'step-1')
     expect(dupStepErr.workflowName).toBe('my-wf')
     expect(dupStepErr.stepName).toBe('step-1')
+
+    const parallelErr = new ParallelCompleteError('analyze')
+    expect(parallelErr.stepName).toBe('analyze')
+    expect(parallelErr).toBeInstanceOf(ReflowError)
+    expect(parallelErr.message).toBe('complete() cannot be called inside parallel step "analyze"')
   })
 })

--- a/src/__tests__/test-engine.test.ts
+++ b/src/__tests__/test-engine.test.ts
@@ -148,4 +148,30 @@ describe('testEngine', () => {
       expect(resultB.steps.go.output).toEqual({ result: 'beta-42' })
     })
   })
+
+  describe('parallel branches', () => {
+    it('returns typed results for parallel branches', async () => {
+      const wf = createWorkflow({
+        name: 'parallel-test',
+        input: z.object({ x: z.number() }),
+      })
+        .step('fetch', async ({ input }) => ({ data: input.x }))
+        .parallel({
+          doubled: async ({ prev }) => ({ result: prev.data * 2 }),
+          tripled: async ({ prev }) => ({ result: prev.data * 3 }),
+        })
+        .step('merge', async ({ prev }) => ({
+          sum: prev.doubled.result + prev.tripled.result,
+        }))
+
+      const te = testEngine({ workflows: [wf] })
+      const result = await te.run('parallel-test', { x: 5 })
+
+      expect(result.status).toBe('completed')
+      expect(result.steps.fetch.output).toEqual({ data: 5 })
+      expect(result.steps.doubled.output).toEqual({ result: 10 })
+      expect(result.steps.tripled.output).toEqual({ result: 15 })
+      expect(result.steps.merge.output).toEqual({ sum: 25 })
+    })
+  })
 })

--- a/src/core/__tests__/parallel-engine.test.ts
+++ b/src/core/__tests__/parallel-engine.test.ts
@@ -503,4 +503,111 @@ describe('Parallel engine execution', () => {
       expect(afterStep?.output).toEqual({ a: { fromA: 'cached' }, b: { fromB: 'cached' } })
     })
   })
+
+  describe('single branch', () => {
+    it('executes a single-branch parallel group with correct prev shape', async () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      })
+        .parallel({
+          only: async () => ({ value: 42 }),
+        })
+        .step('after', async ({ prev }) => ({ received: prev.only.value }))
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('test', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+
+      const afterStep = info.steps.find((s) => s.name === 'after')
+      expect(afterStep?.output).toEqual({ received: 42 })
+    })
+  })
+
+  describe('cancellation', () => {
+    it('cancels a run during parallel execution', async () => {
+      const aborted: string[] = []
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      }).parallel({
+        slow: async ({ signal }) => {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 5000)
+            signal.addEventListener('abort', () => {
+              clearTimeout(timer)
+              aborted.push('slow')
+              reject(signal.reason)
+            })
+          })
+          return { x: 1 }
+        },
+        slower: async ({ signal }) => {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 5000)
+            signal.addEventListener('abort', () => {
+              clearTimeout(timer)
+              aborted.push('slower')
+              reject(signal.reason)
+            })
+          })
+          return { y: 2 }
+        },
+      })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('test', {})
+
+      // Start the tick (non-blocking) then cancel immediately
+      const tickPromise = engine.tick()
+      // Small delay to let branches start
+      await new Promise((r) => setTimeout(r, 20))
+      await engine.cancel(run.id)
+      await tickPromise
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('cancelled')
+      expect(aborted.sort()).toEqual(['slow', 'slower'])
+    })
+  })
+
+  describe('sequential parallel groups', () => {
+    it('chains prev between consecutive parallel groups', async () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      })
+        .parallel({
+          a: async () => ({ x: 10 }),
+          b: async () => ({ y: 20 }),
+        })
+        .parallel({
+          c: async ({ prev }) => ({ sum: prev.a.x + prev.b.y }),
+        })
+        .step('final', async ({ prev, steps }) => ({
+          cResult: prev.c.sum,
+          allSteps: {
+            a: steps.a.x,
+            b: steps.b.y,
+            c: steps.c.sum,
+          },
+        }))
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('test', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+
+      const finalStep = info.steps.find((s) => s.name === 'final')
+      expect(finalStep?.output).toEqual({
+        cResult: 30,
+        allSteps: { a: 10, b: 20, c: 30 },
+      })
+    })
+  })
 })

--- a/src/core/__tests__/parallel-engine.test.ts
+++ b/src/core/__tests__/parallel-engine.test.ts
@@ -1,0 +1,506 @@
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
+import { createWorkflow } from '../workflow'
+import { createEngine } from '../engine'
+import { MemoryStorage } from '../../storage/memory'
+import { ParallelCompleteError } from '../errors'
+import type { PersistedValue } from '../types'
+
+function expectPresent<T>(value: T | null | undefined): T {
+  expect(value).not.toBeNull()
+  expect(value).not.toBeUndefined()
+
+  if (value == null) {
+    throw new Error('Expected value to be present')
+  }
+
+  return value
+}
+
+describe('Parallel engine execution', () => {
+  let storage: MemoryStorage
+
+  beforeEach(async () => {
+    storage = new MemoryStorage()
+    await storage.initialize()
+  })
+
+  describe('basic execution', () => {
+    it('executes parallel branches and merges results correctly', async () => {
+      const wf = createWorkflow({ name: 'parallel-basic', input: z.object({ x: z.number() }) })
+        .parallel({
+          a: async ({ input }) => ({ doubled: input.x * 2 }),
+          b: async ({ input }) => ({ tripled: input.x * 3 }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('parallel-basic', { x: 5 })
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+      expect(info.steps).toHaveLength(2)
+
+      const stepA = info.steps.find((s) => s.name === 'a')
+      const stepB = info.steps.find((s) => s.name === 'b')
+      expect(stepA?.output).toEqual({ doubled: 10 })
+      expect(stepB?.output).toEqual({ tripled: 15 })
+    })
+
+    it('passes correct prev from preceding step to all branches', async () => {
+      const capturedPrevs: PersistedValue[] = []
+
+      const wf = createWorkflow({ name: 'prev-pass', input: z.object({}) })
+        .step('setup', async () => ({ value: 42 }))
+        .parallel({
+          a: async ({ prev }) => {
+            capturedPrevs.push(prev)
+            return { fromA: (prev as { value: number }).value + 1 }
+          },
+          b: async ({ prev }) => {
+            capturedPrevs.push(prev)
+            return { fromB: (prev as { value: number }).value + 2 }
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      await engine.enqueue('prev-pass', {})
+      await engine.tick()
+
+      expect(capturedPrevs).toHaveLength(2)
+      for (const p of capturedPrevs) {
+        expect(p).toEqual({ value: 42 })
+      }
+    })
+
+    it('passes frozen steps snapshot to all branches', async () => {
+      let aFrozen = false
+      let bFrozen = false
+
+      const wf = createWorkflow({ name: 'frozen-steps', input: z.object({}) })
+        .step('setup', async () => ({ nested: { val: 1 } }))
+        .parallel({
+          a: async ({ steps }) => {
+            aFrozen = Object.isFrozen(steps)
+            return {}
+          },
+          b: async ({ steps }) => {
+            bFrozen = Object.isFrozen(steps)
+            return {}
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      await engine.enqueue('frozen-steps', {})
+      await engine.tick()
+
+      expect(aFrozen).toBe(true)
+      expect(bFrozen).toBe(true)
+    })
+
+    it('persists individual step results for each branch', async () => {
+      const wf = createWorkflow({ name: 'persist-branches', input: z.object({}) })
+        .parallel({
+          a: async () => ({ fromA: 1 }),
+          b: async () => ({ fromB: 2 }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('persist-branches', {})
+      await engine.tick()
+
+      const steps = await storage.getStepResults(run.id)
+      expect(steps).toHaveLength(2)
+
+      const stepA = steps.find((s) => s.name === 'a')
+      const stepB = steps.find((s) => s.name === 'b')
+      expect(stepA?.status).toBe('completed')
+      expect(stepA?.output).toEqual({ fromA: 1 })
+      expect(stepB?.status).toBe('completed')
+      expect(stepB?.output).toEqual({ fromB: 2 })
+    })
+
+    it('sets prev to merged record for the step after a parallel group', async () => {
+      let capturedPrev: PersistedValue = undefined
+
+      const wf = createWorkflow({ name: 'merged-prev', input: z.object({}) })
+        .parallel({
+          a: async () => ({ fromA: 10 }),
+          b: async () => ({ fromB: 20 }),
+        })
+        .step('after', async ({ prev }) => {
+          capturedPrev = prev
+          return {}
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      await engine.enqueue('merged-prev', {})
+      await engine.tick()
+
+      expect(capturedPrev).toEqual({ a: { fromA: 10 }, b: { fromB: 20 } })
+    })
+  })
+
+  describe('fail-fast', () => {
+    it('aborts sibling branches when one fails', async () => {
+      let bSignalAborted = false
+
+      const wf = createWorkflow({ name: 'fail-fast', input: z.object({}) })
+        .parallel({
+          a: async () => {
+            throw new Error('branch a failed')
+          },
+          b: async ({ signal }) => {
+            // Wait long enough for a to fail
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 5000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                bSignalAborted = true
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('fail-fast', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('failed')
+      expect(bSignalAborted).toBe(true)
+    })
+
+    it('reports the first failing branch name in onRunFailed', async () => {
+      const onRunFailed = vi.fn()
+
+      const wf = createWorkflow({ name: 'fail-report', input: z.object({}) })
+        .parallel({
+          branchX: async () => {
+            throw new Error('branchX error')
+          },
+          branchY: async ({ signal }) => {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 5000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf], hooks: { onRunFailed } })
+      await engine.enqueue('fail-report', {})
+      await engine.tick()
+
+      expect(onRunFailed).toHaveBeenCalledOnce()
+      expect(onRunFailed).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'branchX' }),
+      )
+    })
+
+    it('calls onFailure handler with failing branch name', async () => {
+      const failHandler = vi.fn(async () => {})
+
+      const wf = createWorkflow({ name: 'fail-handler', input: z.object({ x: z.number() }) })
+        .parallel({
+          broken: async () => {
+            throw new Error('handler error')
+          },
+          ok: async ({ signal }) => {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 5000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+        })
+        .onFailure(failHandler)
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      await engine.enqueue('fail-handler', { x: 1 })
+      await engine.tick()
+
+      expect(failHandler).toHaveBeenCalledOnce()
+      expect(failHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepName: 'broken',
+          error: expect.objectContaining({ message: 'handler error' }),
+        }),
+      )
+    })
+  })
+
+  describe('complete() prevention', () => {
+    it('throws ParallelCompleteError when complete() is called in a branch', async () => {
+      const onRunFailed = vi.fn()
+
+      const wf = createWorkflow({ name: 'no-complete', input: z.object({}) })
+        .parallel({
+          bad: async ({ complete }) => {
+            return complete('done')
+          },
+          good: async ({ signal }) => {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 5000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf], hooks: { onRunFailed } })
+      const run = await engine.enqueue('no-complete', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('failed')
+      expect(onRunFailed).toHaveBeenCalledOnce()
+      expect(onRunFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.any(ParallelCompleteError),
+          stepName: 'bad',
+        }),
+      )
+    })
+  })
+
+  describe('per-branch retry', () => {
+    it('retries a failing branch independently', async () => {
+      let attempts = 0
+
+      const wf = createWorkflow({ name: 'retry-branch', input: z.object({}) })
+        .parallel({
+          flaky: {
+            retry: { maxAttempts: 3, backoff: 'linear', initialDelayMs: 0 },
+            handler: async () => {
+              attempts++
+              if (attempts < 3) {
+                throw new Error('transient')
+              }
+              return { recovered: true }
+            },
+          },
+          stable: async () => ({ stable: true }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('retry-branch', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+      expect(attempts).toBe(3)
+
+      const flakyStep = info.steps.find((s) => s.name === 'flaky')
+      expect(flakyStep?.output).toEqual({ recovered: true })
+      expect(flakyStep?.attempts).toBe(3)
+    })
+  })
+
+  describe('per-branch timeout', () => {
+    it('times out an individual branch without affecting siblings until fail-fast', async () => {
+      const onRunFailed = vi.fn()
+
+      const wf = createWorkflow({ name: 'timeout-branch', input: z.object({}) })
+        .parallel({
+          slow: {
+            timeoutMs: 50,
+            handler: async ({ signal }) => {
+              await new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(resolve, 10_000)
+                signal.addEventListener('abort', () => {
+                  clearTimeout(timer)
+                  reject(signal.reason)
+                }, { once: true })
+              })
+              return {}
+            },
+          },
+          fast: async ({ signal }) => {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 10_000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf], hooks: { onRunFailed } })
+      const run = await engine.enqueue('timeout-branch', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('failed')
+      expect(onRunFailed).toHaveBeenCalledOnce()
+      expect(onRunFailed).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'slow' }),
+      )
+    })
+  })
+
+  describe('hooks', () => {
+    it('fires onStepStart for each branch', async () => {
+      const onStepStart = vi.fn()
+
+      const wf = createWorkflow({ name: 'hooks-start', input: z.object({}) })
+        .parallel({
+          a: async () => ({ fromA: 1 }),
+          b: async () => ({ fromB: 2 }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf], hooks: { onStepStart } })
+      await engine.enqueue('hooks-start', {})
+      await engine.tick()
+
+      expect(onStepStart).toHaveBeenCalledTimes(2)
+      expect(onStepStart).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'a' }),
+      )
+      expect(onStepStart).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'b' }),
+      )
+    })
+
+    it('fires onStepComplete for each branch', async () => {
+      const onStepComplete = vi.fn()
+
+      const wf = createWorkflow({ name: 'hooks-complete', input: z.object({}) })
+        .parallel({
+          a: async () => ({ fromA: 1 }),
+          b: async () => ({ fromB: 2 }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf], hooks: { onStepComplete } })
+      await engine.enqueue('hooks-complete', {})
+      await engine.tick()
+
+      expect(onStepComplete).toHaveBeenCalledTimes(2)
+      expect(onStepComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'a', output: { fromA: 1 }, attempts: 1 }),
+      )
+      expect(onStepComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'b', output: { fromB: 2 }, attempts: 1 }),
+      )
+    })
+  })
+
+  describe('crash recovery', () => {
+    it('re-runs entire parallel group when partially completed', async () => {
+      let branchACalls = 0
+
+      const wf = createWorkflow({ name: 'partial-recovery', input: z.object({}) })
+        .parallel({
+          a: async () => {
+            branchACalls++
+            return { fromA: 'recovered' }
+          },
+          b: async () => ({ fromB: 'new' }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('partial-recovery', {})
+
+      // Simulate partial completion: only branch 'a' was persisted from a previous run
+      const now = Date.now()
+      await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: 'a',
+        status: 'completed',
+        output: { fromA: 'old' },
+        error: null,
+        attempts: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await engine.tick()
+
+      // Branch A should have been re-run (since not ALL branches were complete)
+      expect(branchACalls).toBe(1)
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+
+      // The step results should include the re-run results
+      const stepA = info.steps.find((s) => s.name === 'a' && s.output !== null)
+      const stepB = info.steps.find((s) => s.name === 'b')
+      expect(stepA).toBeDefined()
+      expect(stepB?.output).toEqual({ fromB: 'new' })
+    })
+
+    it('skips parallel group when all branches already completed', async () => {
+      let branchACalls = 0
+      let branchBCalls = 0
+
+      const wf = createWorkflow({ name: 'skip-group', input: z.object({}) })
+        .parallel({
+          a: async () => {
+            branchACalls++
+            return { fromA: 'should-not-run' }
+          },
+          b: async () => {
+            branchBCalls++
+            return { fromB: 'should-not-run' }
+          },
+        })
+        .step('after', async ({ prev }) => prev)
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('skip-group', {})
+
+      // Simulate full completion: both branches were persisted
+      const now = Date.now()
+      await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: 'a',
+        status: 'completed',
+        output: { fromA: 'cached' },
+        error: null,
+        attempts: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: 'b',
+        status: 'completed',
+        output: { fromB: 'cached' },
+        error: null,
+        attempts: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await engine.tick()
+
+      // Neither branch should have been called
+      expect(branchACalls).toBe(0)
+      expect(branchBCalls).toBe(0)
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+
+      // The step after parallel should have received the cached merged output
+      const afterStep = info.steps.find((s) => s.name === 'after')
+      expect(afterStep?.output).toEqual({ a: { fromA: 'cached' }, b: { fromB: 'cached' } })
+    })
+  })
+})

--- a/src/core/__tests__/parallel-engine.test.ts
+++ b/src/core/__tests__/parallel-engine.test.ts
@@ -5,7 +5,7 @@ import { createWorkflow } from '../workflow'
 import { createEngine } from '../engine'
 import { MemoryStorage } from '../../storage/memory'
 import { ParallelCompleteError } from '../errors'
-import type { PersistedValue } from '../types'
+import type { PersistedValue, StorageAdapter } from '../types'
 
 function expectPresent<T>(value: T | null | undefined): T {
   expect(value).not.toBeNull()
@@ -833,6 +833,141 @@ describe('Parallel engine execution', () => {
       const info = expectPresent(await engine.getRunStatus(run.id))
       expect(info.run.status).toBe('cancelled')
       expect(aborted.sort()).toEqual(['slow', 'slower'])
+    })
+  })
+
+  describe('lease loss during parallel persistence', () => {
+    it('returns a failure when the lease is lost while persisting branch results', async () => {
+      // After all branches complete, the engine persists each result via saveStepResult.
+      // If the lease is invalidated mid-loop (e.g. heartbeat lost during execution),
+      // saveStepResult returns false and the engine surfaces a failure rather than
+      // silently corrupting state.
+      const delegate = new MemoryStorage()
+      await delegate.initialize()
+
+      let saveCalls = 0
+      const flakyStorage: StorageAdapter = {
+        initialize: () => delegate.initialize(),
+        createRun: (run) => delegate.createRun(run),
+        claimNextRun: (workflowNames, staleBefore) =>
+          delegate.claimNextRun(workflowNames, staleBefore),
+        heartbeatRun: (runId, leaseId) => delegate.heartbeatRun(runId, leaseId),
+        getRun: (runId) => delegate.getRun(runId),
+        getStepResults: (runId) => delegate.getStepResults(runId),
+        saveStepResult: async (result, leaseId) => {
+          saveCalls++
+          // Drop the first parallel-branch save to simulate lease loss mid-persistence.
+          if (saveCalls === 1) return false
+          return delegate.saveStepResult(result, leaseId)
+        },
+        updateRunStatus: (runId, status) => delegate.updateRunStatus(runId, status),
+        updateClaimedRunStatus: (runId, leaseId, status) =>
+          delegate.updateClaimedRunStatus(runId, leaseId, status),
+        close: () => delegate.close(),
+      }
+
+      const wf = createWorkflow({ name: 'lease-loss', input: z.object({}) })
+        .parallel({
+          a: async () => ({ ok: true }),
+          b: async () => ({ ok: true }),
+        })
+
+      const engine = createEngine({ storage: flakyStorage, workflows: [wf] })
+      const run = await engine.enqueue('lease-loss', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      // Either failed (status update succeeded with the same lease) or running (also
+      // failed to update). Both are valid responses to lease loss; neither is 'completed'.
+      expect(info.run.status).not.toBe('completed')
+    })
+  })
+
+  describe('lease loss mid-branch', () => {
+    it('treats RunControlError from a branch as a skipped-cancelled outcome', async () => {
+      // When the heartbeat fails mid-branch, the active-run signal is aborted with a
+      // LeaseExpiredError. Branches' executeStep rethrows it (RunControlError) without
+      // entering the BranchFailedError path, so causeBranch is never set. The
+      // post-allSettled fallback must recognise the RunControlError and bail.
+      const delegate = new MemoryStorage()
+      await delegate.initialize()
+
+      let heartbeatCalls = 0
+      const flakyStorage: StorageAdapter = {
+        initialize: () => delegate.initialize(),
+        createRun: (run) => delegate.createRun(run),
+        claimNextRun: (workflowNames, staleBefore) =>
+          delegate.claimNextRun(workflowNames, staleBefore),
+        heartbeatRun: async (runId, leaseId) => {
+          heartbeatCalls++
+          if (heartbeatCalls === 1) throw new Error('heartbeat exploded')
+          return delegate.heartbeatRun(runId, leaseId)
+        },
+        getRun: (runId) => delegate.getRun(runId),
+        getStepResults: (runId) => delegate.getStepResults(runId),
+        saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),
+        updateRunStatus: (runId, status) => delegate.updateRunStatus(runId, status),
+        updateClaimedRunStatus: (runId, leaseId, status) =>
+          delegate.updateClaimedRunStatus(runId, leaseId, status),
+        close: () => delegate.close(),
+      }
+
+      const wf = createWorkflow({ name: 'heartbeat-parallel', input: z.object({}) })
+        .parallel({
+          slow: async ({ signal }) => {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 1000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+        })
+
+      const engine = createEngine({
+        storage: flakyStorage,
+        workflows: [wf],
+        runLeaseDurationMs: 30,
+        heartbeatIntervalMs: 5,
+      })
+
+      const run = await engine.enqueue('heartbeat-parallel', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      // The run is not marked completed — lease-loss invalidates the success path.
+      expect(info.run.status).not.toBe('completed')
+    })
+  })
+
+  describe('group entered while already cancelled', () => {
+    it('skips parallel group when the run was cancelled before the group started', async () => {
+      let parallelEntered = false
+
+      const wf = createWorkflow({ name: 'cancelled-before-group', input: z.object({}) })
+        .step('setup', async () => ({ ok: true }))
+        .parallel({
+          a: async () => {
+            parallelEntered = true
+            return { ok: true }
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('cancelled-before-group', {})
+
+      // Cancel before tick() — the run is claimed, setup runs, then cancellation
+      // is detected on the parallel-group boundary check.
+      const tickPromise = engine.tick()
+      // Cancel ASAP; the cancellation may land before or during setup.
+      await engine.cancel(run.id)
+      await tickPromise
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('cancelled')
+      expect(parallelEntered).toBe(false)
     })
   })
 

--- a/src/core/__tests__/parallel-engine.test.ts
+++ b/src/core/__tests__/parallel-engine.test.ts
@@ -204,6 +204,109 @@ describe('Parallel engine execution', () => {
       )
     })
 
+    it('reports the branch that caused the abort, not an aborted sibling', async () => {
+      // When branch B fails first and aborts branch A, A's failure is an induced
+      // side-effect — not the underlying cause. onRunFailed must surface B's name and
+      // B's actual error, otherwise debugging a production incident points at the wrong step.
+      const onRunFailed = vi.fn()
+
+      const wf = createWorkflow({ name: 'cause-reporting', input: z.object({}) })
+        .parallel({
+          first: async ({ signal }) => {
+            // Cooperative wait — will be aborted by 'second' failing.
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 5000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+          second: async () => {
+            throw new Error('underlying cause')
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf], hooks: { onRunFailed } })
+      await engine.enqueue('cause-reporting', {})
+      await engine.tick()
+
+      expect(onRunFailed).toHaveBeenCalledOnce()
+      expect(onRunFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepName: 'second',
+          error: expect.objectContaining({ message: 'underlying cause' }),
+        }),
+      )
+    })
+
+    it('persists only the causing branch as failed, not aborted siblings', async () => {
+      const wf = createWorkflow({ name: 'failed-row-cause', input: z.object({}) })
+        .parallel({
+          aborted: async ({ signal }) => {
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(resolve, 5000)
+              signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(signal.reason)
+              }, { once: true })
+            })
+            return {}
+          },
+          cause: async () => {
+            throw new Error('real failure')
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('failed-row-cause', {})
+      await engine.tick()
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('failed')
+
+      const failedRows = info.steps.filter((s) => s.status === 'failed')
+      expect(failedRows).toHaveLength(1)
+      expect(failedRows[0].name).toBe('cause')
+      expect(failedRows[0].error).toBe('real failure')
+    })
+
+    it('does not surface unhandled rejections when multiple branches fail concurrently', async () => {
+      // Promise.all would consume the first rejection and leave siblings' rejections
+      // unhandled. Promise.allSettled collects all settlements so no listener-less
+      // rejection escapes.
+      const rejections: unknown[] = []
+      const onUnhandled = (reason: unknown) => rejections.push(reason)
+      process.on('unhandledRejection', onUnhandled)
+
+      try {
+        const wf = createWorkflow({ name: 'multi-fail', input: z.object({}) })
+          .parallel({
+            a: async () => {
+              throw new Error('a failed')
+            },
+            b: async () => {
+              throw new Error('b failed')
+            },
+            c: async () => {
+              throw new Error('c failed')
+            },
+          })
+
+        const engine = createEngine({ storage, workflows: [wf] })
+        await engine.enqueue('multi-fail', {})
+        await engine.tick()
+
+        // Give the microtask queue a chance to drain potential unhandled rejections.
+        await new Promise((r) => setTimeout(r, 10))
+
+        expect(rejections).toHaveLength(0)
+      } finally {
+        process.off('unhandledRejection', onUnhandled)
+      }
+    })
+
     it('calls onFailure handler with failing branch name', async () => {
       const failHandler = vi.fn(async () => {})
 
@@ -277,6 +380,44 @@ describe('Parallel engine execution', () => {
   })
 
   describe('per-branch retry', () => {
+    it('does not exhaust retry attempts on a sibling after the group is aborted', async () => {
+      // When branch A fails and aborts the group, branch B (with retries configured)
+      // should bail immediately rather than burning through retries that observe the
+      // already-aborted signal.
+      let bAttempts = 0
+
+      const wf = createWorkflow({ name: 'no-retry-after-abort', input: z.object({}) })
+        .parallel({
+          a: async () => {
+            // small delay so b registers attempts before the abort
+            await new Promise((r) => setTimeout(r, 5))
+            throw new Error('a failed')
+          },
+          b: {
+            retry: { maxAttempts: 5, backoff: 'linear', initialDelayMs: 0 },
+            handler: async ({ signal }) => {
+              bAttempts++
+              await new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(resolve, 1000)
+                signal.addEventListener('abort', () => {
+                  clearTimeout(timer)
+                  reject(signal.reason)
+                }, { once: true })
+              })
+              return {}
+            },
+          },
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      await engine.enqueue('no-retry-after-abort', {})
+      await engine.tick()
+
+      // Even though maxAttempts is 5, b should only have run once before the abort
+      // propagated and stopped further attempts.
+      expect(bAttempts).toBe(1)
+    })
+
     it('retries a failing branch independently', async () => {
       let attempts = 0
 
@@ -400,29 +541,32 @@ describe('Parallel engine execution', () => {
   })
 
   describe('crash recovery', () => {
-    it('re-runs entire parallel group when partially completed', async () => {
+    it('skips already-completed branches and only re-runs missing ones', async () => {
       let branchACalls = 0
+      let branchBCalls = 0
 
       const wf = createWorkflow({ name: 'partial-recovery', input: z.object({}) })
         .parallel({
           a: async () => {
             branchACalls++
-            return { fromA: 'recovered' }
+            return { fromA: 'fresh' }
           },
-          b: async () => ({ fromB: 'new' }),
+          b: async () => {
+            branchBCalls++
+            return { fromB: 'fresh' }
+          },
         })
 
       const engine = createEngine({ storage, workflows: [wf] })
       const run = await engine.enqueue('partial-recovery', {})
 
-      // Simulate partial completion: only branch 'a' was persisted from a previous run
       const now = Date.now()
       await storage.saveStepResult({
         id: randomUUID(),
         runId: run.id,
         name: 'a',
         status: 'completed',
-        output: { fromA: 'old' },
+        output: { fromA: 'cached' },
         error: null,
         attempts: 1,
         createdAt: now,
@@ -431,17 +575,135 @@ describe('Parallel engine execution', () => {
 
       await engine.tick()
 
-      // Branch A should have been re-run (since not ALL branches were complete)
+      expect(branchACalls).toBe(0)
+      expect(branchBCalls).toBe(1)
+
+      const info = expectPresent(await engine.getRunStatus(run.id))
+      expect(info.run.status).toBe('completed')
+
+      // No duplicate rows — exactly one record per branch
+      const rowsA = info.steps.filter((s) => s.name === 'a')
+      const rowsB = info.steps.filter((s) => s.name === 'b')
+      expect(rowsA).toHaveLength(1)
+      expect(rowsB).toHaveLength(1)
+      expect(rowsA[0].output).toEqual({ fromA: 'cached' })
+      expect(rowsB[0].output).toEqual({ fromB: 'fresh' })
+    })
+
+    it('merges cached and fresh branch outputs for the next step', async () => {
+      let capturedPrev: PersistedValue = undefined
+
+      const wf = createWorkflow({ name: 'partial-merge', input: z.object({}) })
+        .parallel({
+          a: async () => ({ fromA: 'fresh' }),
+          b: async () => ({ fromB: 'fresh' }),
+        })
+        .step('after', async ({ prev }) => {
+          capturedPrev = prev
+          return {}
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('partial-merge', {})
+
+      const now = Date.now()
+      await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: 'a',
+        status: 'completed',
+        output: { fromA: 'cached' },
+        error: null,
+        attempts: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await engine.tick()
+
+      expect(capturedPrev).toEqual({ a: { fromA: 'cached' }, b: { fromB: 'fresh' } })
+    })
+
+    it('skips an already-failed branch from a prior run and lets fresh ones complete', async () => {
+      // When the prior run persisted a 'failed' record (e.g. mid-run lease loss), the
+      // engine should retry that branch fresh — failed records don't count as completed.
+      let branchACalls = 0
+
+      const wf = createWorkflow({ name: 'failed-retry', input: z.object({}) })
+        .parallel({
+          a: async () => {
+            branchACalls++
+            return { fromA: 'recovered' }
+          },
+          b: async () => ({ fromB: 'fresh' }),
+        })
+
+      const engine = createEngine({ storage, workflows: [wf] })
+      const run = await engine.enqueue('failed-retry', {})
+
+      const now = Date.now()
+      await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: 'a',
+        status: 'failed',
+        output: null,
+        error: 'prior failure',
+        attempts: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await engine.tick()
+
       expect(branchACalls).toBe(1)
 
       const info = expectPresent(await engine.getRunStatus(run.id))
       expect(info.run.status).toBe('completed')
 
-      // The step results should include the re-run results
-      const stepA = info.steps.find((s) => s.name === 'a' && s.output !== null)
-      const stepB = info.steps.find((s) => s.name === 'b')
-      expect(stepA).toBeDefined()
-      expect(stepB?.output).toEqual({ fromB: 'new' })
+      const completedA = info.steps.find((s) => s.name === 'a' && s.status === 'completed')
+      expect(completedA?.output).toEqual({ fromA: 'recovered' })
+    })
+
+    it('does not fire onStepStart or onStepComplete for already-completed branches on resume', async () => {
+      const onStepStart = vi.fn()
+      const onStepComplete = vi.fn()
+
+      const wf = createWorkflow({ name: 'resume-hooks', input: z.object({}) })
+        .parallel({
+          a: async () => ({ fromA: 'fresh' }),
+          b: async () => ({ fromB: 'fresh' }),
+        })
+
+      const engine = createEngine({
+        storage,
+        workflows: [wf],
+        hooks: { onStepStart, onStepComplete },
+      })
+      const run = await engine.enqueue('resume-hooks', {})
+
+      const now = Date.now()
+      await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: 'a',
+        status: 'completed',
+        output: { fromA: 'cached' },
+        error: null,
+        attempts: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await engine.tick()
+
+      // Only the un-completed branch should fire start/complete
+      expect(onStepStart).toHaveBeenCalledTimes(1)
+      expect(onStepStart).toHaveBeenCalledWith(expect.objectContaining({ stepName: 'b' }))
+      expect(onStepComplete).toHaveBeenCalledTimes(1)
+      expect(onStepComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ stepName: 'b', output: { fromB: 'fresh' } }),
+      )
     })
 
     it('skips parallel group when all branches already completed', async () => {

--- a/src/core/__tests__/parallel-workflow.test.ts
+++ b/src/core/__tests__/parallel-workflow.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createWorkflow } from '../workflow'
+import type { ExecutionUnit, StepDefinition } from '../workflow'
+
+function getParallelBranches(wf: { executionUnits: readonly ExecutionUnit[] }, index: number): readonly StepDefinition[] {
+  const unit = wf.executionUnits[index]
+  if (unit.kind !== 'parallel') throw new Error(`Expected parallel at index ${index}`)
+  return unit.branches
+}
+
+describe('.parallel()', () => {
+  describe('builder basics', () => {
+    it('adds a parallel execution unit', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({ x: z.number() }),
+      })
+        .step('fetch', async ({ input }) => ({ data: input.x }))
+        .parallel({
+          a: async ({ prev }) => ({ fromA: prev.data + 1 }),
+          b: async ({ prev }) => ({ fromB: prev.data + 2 }),
+        })
+
+      expect(wf.executionUnits).toHaveLength(2)
+      const branches = getParallelBranches(wf, 1)
+      expect(branches).toHaveLength(2)
+      expect(branches.map((b) => b.name)).toEqual(['a', 'b'])
+    })
+
+    it('is immutable — returns a new workflow instance', () => {
+      const base = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      }).step('a', async () => ({ x: 1 }))
+
+      const withParallel = base.parallel({
+        b: async () => ({ y: 1 }),
+        c: async () => ({ z: 1 }),
+      })
+
+      expect(base.executionUnits).toHaveLength(1)
+      expect(withParallel.executionUnits).toHaveLength(2)
+    })
+
+    it('allows chaining .step() after .parallel()', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({ x: z.number() }),
+      })
+        .step('fetch', async ({ input }) => ({ data: input.x }))
+        .parallel({
+          a: async () => ({ fromA: 1 }),
+          b: async () => ({ fromB: 2 }),
+        })
+        .step('merge', async ({ prev }) => ({ sum: prev.a.fromA + prev.b.fromB }))
+
+      expect(wf.executionUnits).toHaveLength(3)
+      expect(wf.executionUnits[2].kind).toBe('step')
+    })
+
+    it('allows chaining .parallel() after .parallel()', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      })
+        .parallel({
+          a: async () => ({ x: 1 }),
+          b: async () => ({ y: 2 }),
+        })
+        .parallel({
+          c: async () => ({ z: 3 }),
+          d: async () => ({ w: 4 }),
+        })
+
+      expect(wf.executionUnits).toHaveLength(2)
+      expect(wf.executionUnits[0].kind).toBe('parallel')
+      expect(wf.executionUnits[1].kind).toBe('parallel')
+    })
+
+    it('preserves onFailure through parallel chaining', () => {
+      const handler = async () => {}
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      })
+        .onFailure(handler)
+        .parallel({
+          a: async () => ({ x: 1 }),
+        })
+
+      expect(wf.failureHandler).toBe(handler)
+    })
+  })
+
+  describe('branch configuration', () => {
+    it('accepts bare handler functions', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      }).parallel({
+        a: async () => ({ x: 1 }),
+      })
+
+      const branches = getParallelBranches(wf, 0)
+      expect(branches[0].retry).toBeUndefined()
+      expect(branches[0].timeoutMs).toBeUndefined()
+    })
+
+    it('accepts config objects with retry and timeout', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      }).parallel({
+        a: {
+          retry: { maxAttempts: 3, backoff: 'exponential' as const },
+          timeoutMs: 5000,
+          handler: async () => ({ x: 1 }),
+        },
+      })
+
+      const branches = getParallelBranches(wf, 0)
+      expect(branches[0].retry).toEqual({
+        maxAttempts: 3,
+        backoff: 'exponential',
+      })
+      expect(branches[0].timeoutMs).toBe(5000)
+    })
+
+    it('accepts a mix of bare handlers and config objects', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      }).parallel({
+        a: async () => ({ x: 1 }),
+        b: {
+          retry: { maxAttempts: 2, backoff: 'linear' as const },
+          handler: async () => ({ y: 2 }),
+        },
+      })
+
+      const branches = getParallelBranches(wf, 0)
+      expect(branches[0].retry).toBeUndefined()
+      expect(branches[1].retry).toEqual({
+        maxAttempts: 2,
+        backoff: 'linear',
+      })
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects empty parallel object', () => {
+      const wf = createWorkflow({
+        name: 'test',
+        input: z.object({}),
+      })
+
+      expect(() => wf.parallel({})).toThrow('parallel() requires at least one branch')
+    })
+
+    it('rejects branch name that conflicts with existing step', () => {
+      const wf = createWorkflow({
+        name: 'dup-test',
+        input: z.object({}),
+      }).step('fetch', async () => ({ x: 1 }))
+
+      expect(() =>
+        wf.parallel({
+          fetch: async () => ({ y: 2 }),
+        }),
+      ).toThrow('Step "fetch" is already defined in workflow "dup-test"')
+    })
+
+    it('rejects branch name that conflicts with a branch in a prior parallel group', () => {
+      const wf = createWorkflow({
+        name: 'dup-test',
+        input: z.object({}),
+      }).parallel({
+        analyze: async () => ({ x: 1 }),
+      })
+
+      expect(() =>
+        wf.parallel({
+          analyze: async () => ({ y: 2 }),
+        }),
+      ).toThrow('Step "analyze" is already defined in workflow "dup-test"')
+    })
+
+    it('rejects step name that conflicts with a branch in a prior parallel group', () => {
+      const wf = createWorkflow({
+        name: 'dup-test',
+        input: z.object({}),
+      }).parallel({
+        analyze: async () => ({ x: 1 }),
+      })
+
+      expect(() => wf.step('analyze', async () => ({}))).toThrow(
+        'Step "analyze" is already defined in workflow "dup-test"',
+      )
+    })
+  })
+})

--- a/src/core/__tests__/type-safety.test.ts
+++ b/src/core/__tests__/type-safety.test.ts
@@ -153,4 +153,98 @@ describe('type safety', () => {
         return {}
       })
   })
+
+  describe('parallel type safety', () => {
+    it('prev after parallel is a merged record of branch outputs', () => {
+      createWorkflow({ name: 'par-prev', input: z.object({ x: z.number() }) })
+        .step('fetch', async ({ input }) => ({ data: input.x }))
+        .parallel({
+          a: async ({ prev }) => {
+            expectTypeOf(prev).toEqualTypeOf<{ data: number }>()
+            return { fromA: prev.data + 1 }
+          },
+          b: async ({ prev }) => {
+            expectTypeOf(prev).toEqualTypeOf<{ data: number }>()
+            return { fromB: prev.data + 2 }
+          },
+        })
+        .step('merge', async ({ prev }) => {
+          expectTypeOf(prev).toEqualTypeOf<{ a: { fromA: number }; b: { fromB: number } }>()
+          return { sum: prev.a.fromA + prev.b.fromB }
+        })
+    })
+
+    it('steps accumulates parallel branch outputs individually', () => {
+      createWorkflow({ name: 'par-steps', input: z.object({ x: z.number() }) })
+        .step('fetch', async () => ({ data: 1 }))
+        .parallel({
+          a: async () => ({ fromA: 1 }),
+          b: async () => ({ fromB: 2 }),
+        })
+        .step('after', async ({ steps }) => {
+          expectTypeOf(steps.fetch).toEqualTypeOf<{ data: number }>()
+          expectTypeOf(steps.a).toEqualTypeOf<{ fromA: number }>()
+          expectTypeOf(steps.b).toEqualTypeOf<{ fromB: number }>()
+          return {}
+        })
+    })
+
+    it('parallel branches receive input and steps from prior steps', () => {
+      createWorkflow({ name: 'par-ctx', input: z.object({ url: z.string() }) })
+        .step('fetch', async ({ input }) => ({ data: input.url }))
+        .parallel({
+          a: async ({ input, steps }) => {
+            expectTypeOf(input).toEqualTypeOf<{ url: string }>()
+            expectTypeOf(steps.fetch).toEqualTypeOf<{ data: string }>()
+            return { x: 1 }
+          },
+        })
+    })
+
+    it('first step prev is undefined in parallel when no prior step', () => {
+      createWorkflow({ name: 'par-first', input: z.object({}) })
+        .parallel({
+          a: async ({ prev }) => {
+            expectTypeOf(prev).toEqualTypeOf<undefined>()
+            return { x: 1 }
+          },
+        })
+    })
+
+    it('chained parallels — second parallel prev is first parallel merged result', () => {
+      createWorkflow({ name: 'par-chain', input: z.object({}) })
+        .parallel({
+          a: async () => ({ x: 1 }),
+          b: async () => ({ y: 2 }),
+        })
+        .parallel({
+          c: async ({ prev }) => {
+            expectTypeOf(prev).toEqualTypeOf<{ a: { x: number }; b: { y: number } }>()
+            return { z: prev.a.x + prev.b.y }
+          },
+        })
+    })
+
+    it('testEngine returns typed results for parallel branches', () => {
+      const wf = createWorkflow({ name: 'par-te', input: z.object({ x: z.number() }) })
+        .step('fetch', async ({ input }) => ({ data: input.x }))
+        .parallel({
+          a: async ({ prev }) => ({ doubled: prev.data * 2 }),
+          b: async ({ prev }) => ({ tripled: prev.data * 3 }),
+        })
+
+      const te = testEngine({ workflows: [wf] })
+
+      // Verify the run method returns correctly typed results
+      type Result = Awaited<ReturnType<typeof te.run<'par-te'>>>
+      expectTypeOf<Result['steps']['a']>().toEqualTypeOf<
+        | { status: 'completed'; output: { doubled: number }; error: null }
+        | { status: 'failed'; output: null; error: string }
+      >()
+      expectTypeOf<Result['steps']['b']>().toEqualTypeOf<
+        | { status: 'completed'; output: { tripled: number }; error: null }
+        | { status: 'failed'; output: null; error: string }
+      >()
+    })
+  })
 })

--- a/src/core/__tests__/type-safety.test.ts
+++ b/src/core/__tests__/type-safety.test.ts
@@ -34,7 +34,7 @@ describe('type safety', () => {
       expectTypeOf(input).toEqualTypeOf<OrderInput>()
       return { ok: true }
     })
-    expect(wf.steps).toHaveLength(1)
+    expect(wf.executionUnits).toHaveLength(1)
   })
 
   it('prev type flows from previous step output', () => {

--- a/src/core/__tests__/workflow.test.ts
+++ b/src/core/__tests__/workflow.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
 import { createWorkflow } from '../workflow'
+import type { ExecutionUnit, StepDefinition } from '../workflow'
+
+function getStepDef(wf: { executionUnits: readonly ExecutionUnit[] }, index: number): StepDefinition {
+  const unit = wf.executionUnits[index]
+  if (unit.kind !== 'step') throw new Error(`Expected step at index ${index}`)
+  return unit.definition
+}
 
 describe('createWorkflow', () => {
   describe('builder basics', () => {
@@ -11,7 +18,7 @@ describe('createWorkflow', () => {
       })
 
       expect(wf.name).toBe('test')
-      expect(wf.steps).toHaveLength(0)
+      expect(wf.executionUnits).toHaveLength(0)
       expect(wf.failureHandler).toBeUndefined()
     })
 
@@ -32,9 +39,9 @@ describe('createWorkflow', () => {
         .step('first', async ({ input }) => ({ a: input.x + 1 }))
         .step('second', async ({ prev }) => ({ b: prev.a * 2 }))
 
-      expect(wf.steps).toHaveLength(2)
-      expect(wf.steps[0].name).toBe('first')
-      expect(wf.steps[1].name).toBe('second')
+      expect(wf.executionUnits).toHaveLength(2)
+      expect(getStepDef(wf, 0).name).toBe('first')
+      expect(getStepDef(wf, 1).name).toBe('second')
     })
 
     it('is immutable — each .step() returns a new workflow instance', () => {
@@ -46,11 +53,11 @@ describe('createWorkflow', () => {
       const withA = base.step('a', async () => ({ x: 1 }))
       const withB = base.step('b', async () => ({ y: 2 }))
 
-      expect(base.steps).toHaveLength(0)
-      expect(withA.steps).toHaveLength(1)
-      expect(withA.steps[0].name).toBe('a')
-      expect(withB.steps).toHaveLength(1)
-      expect(withB.steps[0].name).toBe('b')
+      expect(base.executionUnits).toHaveLength(0)
+      expect(withA.executionUnits).toHaveLength(1)
+      expect(getStepDef(withA, 0).name).toBe('a')
+      expect(withB.executionUnits).toHaveLength(1)
+      expect(getStepDef(withB, 0).name).toBe('b')
     })
 
     it('supports long chains (5+ steps)', () => {
@@ -64,8 +71,11 @@ describe('createWorkflow', () => {
         .step('s4', async ({ prev }) => ({ v: prev.v + 1 }))
         .step('s5', async ({ prev }) => ({ v: prev.v + 1 }))
 
-      expect(wf.steps).toHaveLength(5)
-      expect(wf.steps.map((s) => s.name)).toEqual(['s1', 's2', 's3', 's4', 's5'])
+      expect(wf.executionUnits).toHaveLength(5)
+      expect(wf.executionUnits.map((u) => {
+        if (u.kind !== 'step') throw new Error('expected step')
+        return u.definition.name
+      })).toEqual(['s1', 's2', 's3', 's4', 's5'])
     })
 
     it('preserves the workflow name through chaining', () => {
@@ -99,7 +109,7 @@ describe('createWorkflow', () => {
         input: z.object({}),
       }).step('simple', handler)
 
-      expect(wf.steps[0].retry).toBeUndefined()
+      expect(getStepDef(wf, 0).retry).toBeUndefined()
     })
 
     it('accepts a config object with handler and retry', () => {
@@ -111,8 +121,8 @@ describe('createWorkflow', () => {
         handler: async ({ input }) => ({ result: input.x }),
       })
 
-      expect(wf.steps[0].name).toBe('retryable')
-      expect(wf.steps[0].retry).toEqual({
+      expect(getStepDef(wf, 0).name).toBe('retryable')
+      expect(getStepDef(wf, 0).retry).toEqual({
         maxAttempts: 3,
         backoff: 'exponential',
       })
@@ -127,7 +137,7 @@ describe('createWorkflow', () => {
         handler: async () => ({}),
       })
 
-      expect(wf.steps[0].retry).toEqual({
+      expect(getStepDef(wf, 0).retry).toEqual({
         maxAttempts: 5,
         backoff: 'linear',
         initialDelayMs: 500,
@@ -220,7 +230,7 @@ describe('createWorkflow', () => {
         .step('b', async ({ prev }) => ({ y: prev.x + 1 }))
 
       expect(wf.failureHandler).toBe(failHandler)
-      expect(wf.steps).toHaveLength(2)
+      expect(wf.executionUnits).toHaveLength(2)
     })
   })
 })

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -354,188 +354,33 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
             return
           }
         } else {
-          // unit.kind === 'parallel'
-          const branches = unit.branches
-
-          if (activeRun.runAbortController.signal.aborted) {
-            const latestRun = await storage.getRun(run.id)
-            if (!latestRun || latestRun.status === 'cancelled') {
-              return
-            }
+          const result = await executeParallelGroup(run, activeRun, unit.branches, prev, stepsAccumulator, completedMap)
+          if (result.kind === 'skipped-cancelled') {
+            return
           }
-
-          // Check crash recovery: if ALL branches have completed results, skip the group
-          const allCompleted = branches.every((b) => completedMap.get(b.name)?.status === 'completed')
-          if (allCompleted) {
-            const merged: Record<string, PersistedValue> = {}
-            for (const branchDef of branches) {
-              const existing = completedMap.get(branchDef.name)
-              if (existing) {
-                merged[branchDef.name] = existing.output
-                stepsAccumulator[branchDef.name] = structuredClone(existing.output)
-              }
-            }
-            prev = merged
-            continue
-          }
-
-          // Not all completed — re-run the entire group
-          const frozenSteps = snapshotSteps(stepsAccumulator)
-
-          const groupAbort = new AbortController()
-          const onRunAbort = () => {
-            if (!groupAbort.signal.aborted) {
-              groupAbort.abort(activeRun.runAbortController.signal.reason)
-            }
-          }
-          if (activeRun.runAbortController.signal.aborted) {
-            groupAbort.abort(activeRun.runAbortController.signal.reason)
-          } else {
-            activeRun.runAbortController.signal.addEventListener('abort', onRunAbort, { once: true })
-          }
-
-          try {
-            for (const branchDef of branches) {
-              try {
-                hooks?.onStepStart?.({ runId: run.id, stepName: branchDef.name })
-              } catch { /* hooks must not affect engine state */ }
-            }
-
-            const groupActiveRun: ActiveRunState = {
-              ...activeRun,
-              runAbortController: groupAbort,
-            }
-
-            const results = await Promise.all(
-              branches.map(async (branchDef) => {
-                const guardedHandler: StepDefinition['handler'] = (ctx) => {
-                  const guardedComplete = (): never => {
-                    throw new ParallelCompleteError(branchDef.name)
-                  }
-                  return branchDef.handler({ ...ctx, complete: guardedComplete })
-                }
-
-                const guardedDef: StepDefinition = { ...branchDef, handler: guardedHandler }
-                const outcome = await executeStep(run, groupActiveRun, guardedDef, prev, frozenSteps)
-
-                if (outcome.kind === 'failed') {
-                  if (!groupAbort.signal.aborted) {
-                    groupAbort.abort(outcome.error)
-                  }
-                  throw new BranchFailedError(branchDef.name, outcome.error, outcome.attempts)
-                }
-
-                if (outcome.kind === 'early-complete') {
-                  const err = new ParallelCompleteError(branchDef.name)
-                  if (!groupAbort.signal.aborted) {
-                    groupAbort.abort(err)
-                  }
-                  throw new BranchFailedError(branchDef.name, err, outcome.attempts)
-                }
-
-                return { name: branchDef.name, output: outcome.output, attempts: outcome.attempts }
-              }),
-            )
-
-            // All branches succeeded — persist results
-            for (const result of results) {
-              const now = Date.now()
-              const saved = await storage.saveStepResult({
-                id: randomUUID(),
-                runId: run.id,
-                name: result.name,
-                status: 'completed',
-                output: result.output,
-                error: null,
-                attempts: result.attempts,
-                createdAt: now,
-                updatedAt: now,
-              }, run.leaseId)
-
-              if (!saved) {
-                throw new LeaseExpiredError(run.id)
-              }
-
-              try {
-                hooks?.onStepComplete?.({
-                  runId: run.id,
-                  stepName: result.name,
-                  output: result.output,
-                  attempts: result.attempts,
-                })
-              } catch { /* hooks must not affect engine state */ }
-
-              stepsAccumulator[result.name] = structuredClone(result.output)
-            }
-
-            const merged: Record<string, PersistedValue> = {}
-            for (const result of results) {
-              merged[result.name] = result.output
-            }
-            prev = merged
-          } catch (error) {
-            const err = error instanceof Error ? error : new Error(String(error))
-
-            if (err instanceof EarlyCompleteError) {
-              throw new Error('EarlyCompleteError escaped executeStep in parallel group')
-            }
-
-            if (err instanceof RunControlError) {
-              return
-            }
-
-            if (activeRun.runAbortController.signal.aborted) {
-              const currentRun = await storage.getRun(run.id)
-              if (!currentRun || currentRun.status === 'cancelled') {
-                return
-              }
-            }
-
-            const branchName = err instanceof BranchFailedError ? err.branchName : branches[0].name
-            const branchAttempts = err instanceof BranchFailedError ? err.attempts : 1
-            const branchError = err instanceof BranchFailedError ? err.branchError : err
-
-            // Persist the failed step result
-            const now = Date.now()
-            const saved = await storage.saveStepResult({
-              id: randomUUID(),
-              runId: run.id,
-              name: branchName,
-              status: 'failed',
-              output: null,
-              error: branchError.message,
-              attempts: branchAttempts,
-              createdAt: now,
-              updatedAt: now,
-            }, run.leaseId)
-
-            if (!saved) {
-              return
-            }
-
+          if (result.kind === 'failed') {
             const failed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'failed')
             if (!failed) {
               return
             }
 
             try {
-              hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: branchName, error: branchError })
+              hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: result.branchName, error: result.error })
             } catch { /* hooks must not affect engine state */ }
 
             if (wf.failureHandler) {
               try {
                 await wf.failureHandler({
-                  error: branchError,
-                  stepName: branchName,
+                  error: result.error,
+                  stepName: result.branchName,
                   input: run.input,
                 })
               } catch { /* onFailure must not affect engine state */ }
             }
 
             return
-          } finally {
-            activeRun.runAbortController.signal.removeEventListener('abort', onRunAbort)
           }
+          prev = result.merged
         }
       }
 
@@ -626,6 +471,178 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     }
 
     return { kind: 'failed', error: lastError ?? new Error('Unknown error'), attempts: maxAttempts }
+  }
+
+  type ParallelGroupResult =
+    | { kind: 'completed'; merged: Record<string, PersistedValue> }
+    | { kind: 'skipped-cancelled' }
+    | { kind: 'failed'; branchName: string; error: Error }
+
+  async function executeParallelGroup(
+    run: ClaimedRun,
+    activeRun: ActiveRunState,
+    branches: readonly StepDefinition[],
+    prev: PersistedValue,
+    stepsAccumulator: Record<string, PersistedValue>,
+    completedMap: Map<string, { status: string; output: PersistedValue; attempts: number }>,
+  ): Promise<ParallelGroupResult> {
+    if (activeRun.runAbortController.signal.aborted) {
+      const latestRun = await storage.getRun(run.id)
+      if (!latestRun || latestRun.status === 'cancelled') {
+        return { kind: 'skipped-cancelled' }
+      }
+    }
+
+    // Crash recovery: if ALL branches have completed results, skip the group
+    const allCompleted = branches.every((b) => completedMap.get(b.name)?.status === 'completed')
+    if (allCompleted) {
+      const merged: Record<string, PersistedValue> = {}
+      for (const branchDef of branches) {
+        const existing = completedMap.get(branchDef.name)
+        if (existing) {
+          merged[branchDef.name] = existing.output
+          stepsAccumulator[branchDef.name] = structuredClone(existing.output)
+        }
+      }
+      return { kind: 'completed', merged }
+    }
+
+    // Not all completed — re-run the entire group
+    const frozenSteps = snapshotSteps(stepsAccumulator)
+
+    const groupAbort = new AbortController()
+    const onRunAbort = () => {
+      if (!groupAbort.signal.aborted) {
+        groupAbort.abort(activeRun.runAbortController.signal.reason)
+      }
+    }
+    if (activeRun.runAbortController.signal.aborted) {
+      groupAbort.abort(activeRun.runAbortController.signal.reason)
+    } else {
+      activeRun.runAbortController.signal.addEventListener('abort', onRunAbort, { once: true })
+    }
+
+    try {
+      for (const branchDef of branches) {
+        try {
+          hooks?.onStepStart?.({ runId: run.id, stepName: branchDef.name })
+        } catch { /* hooks must not affect engine state */ }
+      }
+
+      const groupActiveRun: ActiveRunState = {
+        ...activeRun,
+        runAbortController: groupAbort,
+      }
+
+      const results = await Promise.all(
+        branches.map(async (branchDef) => {
+          const guardedHandler: StepDefinition['handler'] = (ctx) => {
+            const guardedComplete = (): never => {
+              throw new ParallelCompleteError(branchDef.name)
+            }
+            return branchDef.handler({ ...ctx, complete: guardedComplete })
+          }
+
+          const guardedDef: StepDefinition = { ...branchDef, handler: guardedHandler }
+          const outcome = await executeStep(run, groupActiveRun, guardedDef, prev, frozenSteps)
+
+          if (outcome.kind === 'failed') {
+            if (!groupAbort.signal.aborted) {
+              groupAbort.abort(outcome.error)
+            }
+            throw new BranchFailedError(branchDef.name, outcome.error, outcome.attempts)
+          }
+
+          if (outcome.kind === 'early-complete') {
+            const err = new ParallelCompleteError(branchDef.name)
+            if (!groupAbort.signal.aborted) {
+              groupAbort.abort(err)
+            }
+            throw new BranchFailedError(branchDef.name, err, outcome.attempts)
+          }
+
+          return { name: branchDef.name, output: outcome.output, attempts: outcome.attempts }
+        }),
+      )
+
+      // All branches succeeded — persist results
+      const merged: Record<string, PersistedValue> = {}
+      for (const result of results) {
+        const now = Date.now()
+        const saved = await storage.saveStepResult({
+          id: randomUUID(),
+          runId: run.id,
+          name: result.name,
+          status: 'completed',
+          output: result.output,
+          error: null,
+          attempts: result.attempts,
+          createdAt: now,
+          updatedAt: now,
+        }, run.leaseId)
+
+        if (!saved) {
+          throw new LeaseExpiredError(run.id)
+        }
+
+        try {
+          hooks?.onStepComplete?.({
+            runId: run.id,
+            stepName: result.name,
+            output: result.output,
+            attempts: result.attempts,
+          })
+        } catch { /* hooks must not affect engine state */ }
+
+        stepsAccumulator[result.name] = structuredClone(result.output)
+        merged[result.name] = result.output
+      }
+
+      return { kind: 'completed', merged }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error))
+
+      if (err instanceof EarlyCompleteError) {
+        throw new Error('EarlyCompleteError escaped executeStep in parallel group')
+      }
+
+      if (err instanceof RunControlError) {
+        return { kind: 'skipped-cancelled' }
+      }
+
+      if (activeRun.runAbortController.signal.aborted) {
+        const currentRun = await storage.getRun(run.id)
+        if (!currentRun || currentRun.status === 'cancelled') {
+          return { kind: 'skipped-cancelled' }
+        }
+      }
+
+      const branchName = err instanceof BranchFailedError ? err.branchName : branches[0].name
+      const branchAttempts = err instanceof BranchFailedError ? err.attempts : 1
+      const branchError = err instanceof BranchFailedError ? err.branchError : err
+
+      // Persist the failed step result
+      const now = Date.now()
+      const saved = await storage.saveStepResult({
+        id: randomUUID(),
+        runId: run.id,
+        name: branchName,
+        status: 'failed',
+        output: null,
+        error: branchError.message,
+        attempts: branchAttempts,
+        createdAt: now,
+        updatedAt: now,
+      }, run.leaseId)
+
+      if (!saved) {
+        return { kind: 'failed', branchName, error: branchError }
+      }
+
+      return { kind: 'failed', branchName, error: branchError }
+    } finally {
+      activeRun.runAbortController.signal.removeEventListener('abort', onRunAbort)
+    }
   }
 
   async function cancel(runId: string): Promise<boolean> {
@@ -969,7 +986,10 @@ function deepFreeze<T extends Record<string, unknown>>(obj: T): T {
   return obj
 }
 
-/** Internal wrapper for carrying branch metadata through Promise.all rejections. */
+/**
+ * Carries branch metadata (name, original error, attempts) through Promise.all rejections.
+ * @internal Not exported from the public API.
+ */
 class BranchFailedError extends Error {
   constructor(
     public readonly branchName: string,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -202,7 +202,11 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
       let prev: PersistedValue = undefined
       const stepsAccumulator: Record<string, PersistedValue> = {}
 
-      for (const stepDef of wf.steps) {
+      for (const unit of wf.executionUnits) {
+        if (unit.kind !== 'step') {
+          throw new Error(`Unsupported execution unit kind: ${unit.kind}`)
+        }
+        const stepDef = unit.definition
         if (activeRun.runAbortController.signal.aborted) {
           const latestRun = await storage.getRun(run.id)
           if (!latestRun || latestRun.status === 'cancelled') {

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -6,6 +6,7 @@ import {
   EarlyCompleteError,
   IdempotencyConflictError,
   LeaseExpiredError,
+  ParallelCompleteError,
   RunCancelledError,
   RunControlError,
   StepTimeoutError,
@@ -15,7 +16,6 @@ import type {
   ClaimedRun,
   PersistedValue,
   RunInfo,
-  StepResult,
   StorageAdapter,
   WorkflowRun,
 } from './types'
@@ -203,105 +203,27 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
       const stepsAccumulator: Record<string, PersistedValue> = {}
 
       for (const unit of wf.executionUnits) {
-        if (unit.kind !== 'step') {
-          throw new Error(`Unsupported execution unit kind: ${unit.kind}`)
-        }
-        const stepDef = unit.definition
-        if (activeRun.runAbortController.signal.aborted) {
-          const latestRun = await storage.getRun(run.id)
-          if (!latestRun || latestRun.status === 'cancelled') {
-            return
-          }
-        }
-
-        const existing = completedMap.get(stepDef.name)
-        if (existing?.status === 'completed-early') {
-          // This step called complete() in a previous execution — finish the run
-          try {
-            hooks?.onStepComplete?.({
-              runId: run.id,
-              stepName: stepDef.name,
-              output: existing.output,
-              attempts: existing.attempts,
-            })
-          } catch { /* hooks must not affect engine state */ }
-
-          const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
-          if (!completed) {
-            throw new LeaseExpiredError(run.id)
-          }
-
-          try {
-            hooks?.onRunComplete?.({ runId: run.id, workflow: run.workflow })
-          } catch { /* hooks must not affect engine state */ }
-
-          return
-        }
-        if (existing?.status === 'completed') {
-          prev = existing.output
-          stepsAccumulator[stepDef.name] = structuredClone(existing.output)
-          continue
-        }
-
-        const frozenSteps = snapshotSteps(stepsAccumulator)
-
-        try {
-          try {
-            hooks?.onStepStart?.({ runId: run.id, stepName: stepDef.name })
-          } catch { /* hooks must not affect engine state */ }
-
-          const outcome = await executeStep(run, activeRun, stepDef, prev, frozenSteps)
-
-          if (outcome.kind === 'failed') {
-            // Persist the failed step result
-            const now = Date.now()
-            const saved = await storage.saveStepResult({
-              id: randomUUID(),
-              runId: run.id,
-              name: stepDef.name,
-              status: 'failed',
-              output: null,
-              error: outcome.error.message,
-              attempts: outcome.attempts,
-              createdAt: now,
-              updatedAt: now,
-            }, run.leaseId)
-
-            if (!saved) {
-              throw new LeaseExpiredError(run.id)
+        if (unit.kind === 'step') {
+          const stepDef = unit.definition
+          if (activeRun.runAbortController.signal.aborted) {
+            const latestRun = await storage.getRun(run.id)
+            if (!latestRun || latestRun.status === 'cancelled') {
+              return
             }
-
-            throw outcome.error
           }
 
-          // Unified success path for both normal and early completion
-          const now = Date.now()
-          const saved = await storage.saveStepResult({
-            id: randomUUID(),
-            runId: run.id,
-            name: stepDef.name,
-            status: outcome.kind === 'early-complete' ? 'completed-early' : 'completed',
-            output: outcome.output,
-            error: null,
-            attempts: outcome.attempts,
-            createdAt: now,
-            updatedAt: now,
-          }, run.leaseId)
+          const existing = completedMap.get(stepDef.name)
+          if (existing?.status === 'completed-early') {
+            // This step called complete() in a previous execution — finish the run
+            try {
+              hooks?.onStepComplete?.({
+                runId: run.id,
+                stepName: stepDef.name,
+                output: existing.output,
+                attempts: existing.attempts,
+              })
+            } catch { /* hooks must not affect engine state */ }
 
-          if (!saved) {
-            throw new LeaseExpiredError(run.id)
-          }
-
-          try {
-            hooks?.onStepComplete?.({
-              runId: run.id,
-              stepName: stepDef.name,
-              output: outcome.output,
-              attempts: outcome.attempts,
-            })
-          } catch { /* hooks must not affect engine state */ }
-
-          if (outcome.kind === 'early-complete') {
             const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
             if (!completed) {
               throw new LeaseExpiredError(run.id)
@@ -313,47 +235,307 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
             return
           }
-
-          prev = outcome.output
-          stepsAccumulator[stepDef.name] = structuredClone(prev)
-        } catch (error) {
-          const err = error instanceof Error ? error : new Error(String(error))
-
-          if (err instanceof EarlyCompleteError) {
-            throw new Error(`EarlyCompleteError escaped executeStep for step "${stepDef.name}"`)
+          if (existing?.status === 'completed') {
+            prev = existing.output
+            stepsAccumulator[stepDef.name] = structuredClone(existing.output)
+            continue
           }
 
-          if (err instanceof RunControlError) {
+          const frozenSteps = snapshotSteps(stepsAccumulator)
+
+          try {
+            try {
+              hooks?.onStepStart?.({ runId: run.id, stepName: stepDef.name })
+            } catch { /* hooks must not affect engine state */ }
+
+            const outcome = await executeStep(run, activeRun, stepDef, prev, frozenSteps)
+
+            if (outcome.kind === 'failed') {
+              // Persist the failed step result
+              const now = Date.now()
+              const saved = await storage.saveStepResult({
+                id: randomUUID(),
+                runId: run.id,
+                name: stepDef.name,
+                status: 'failed',
+                output: null,
+                error: outcome.error.message,
+                attempts: outcome.attempts,
+                createdAt: now,
+                updatedAt: now,
+              }, run.leaseId)
+
+              if (!saved) {
+                throw new LeaseExpiredError(run.id)
+              }
+
+              throw outcome.error
+            }
+
+            // Unified success path for both normal and early completion
+            const now = Date.now()
+            const saved = await storage.saveStepResult({
+              id: randomUUID(),
+              runId: run.id,
+              name: stepDef.name,
+              status: outcome.kind === 'early-complete' ? 'completed-early' : 'completed',
+              output: outcome.output,
+              error: null,
+              attempts: outcome.attempts,
+              createdAt: now,
+              updatedAt: now,
+            }, run.leaseId)
+
+            if (!saved) {
+              throw new LeaseExpiredError(run.id)
+            }
+
+            try {
+              hooks?.onStepComplete?.({
+                runId: run.id,
+                stepName: stepDef.name,
+                output: outcome.output,
+                attempts: outcome.attempts,
+              })
+            } catch { /* hooks must not affect engine state */ }
+
+            if (outcome.kind === 'early-complete') {
+              const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
+              if (!completed) {
+                throw new LeaseExpiredError(run.id)
+              }
+
+              try {
+                hooks?.onRunComplete?.({ runId: run.id, workflow: run.workflow })
+              } catch { /* hooks must not affect engine state */ }
+
+              return
+            }
+
+            prev = outcome.output
+            stepsAccumulator[stepDef.name] = structuredClone(prev)
+          } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error))
+
+            if (err instanceof EarlyCompleteError) {
+              throw new Error(`EarlyCompleteError escaped executeStep for step "${stepDef.name}"`)
+            }
+
+            if (err instanceof RunControlError) {
+              return
+            }
+
+            if (activeRun.runAbortController.signal.aborted) {
+              const currentRun = await storage.getRun(run.id)
+              if (!currentRun || currentRun.status === 'cancelled') {
+                return
+              }
+            }
+
+            const failed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'failed')
+            if (!failed) {
+              return
+            }
+
+            try {
+              hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: stepDef.name, error: err })
+            } catch { /* hooks must not affect engine state */ }
+
+            if (wf.failureHandler) {
+              try {
+                await wf.failureHandler({
+                  error: err,
+                  stepName: stepDef.name,
+                  input: run.input,
+                })
+              } catch { /* onFailure must not affect engine state */ }
+            }
+
             return
           }
+        } else {
+          // unit.kind === 'parallel'
+          const branches = unit.branches
 
           if (activeRun.runAbortController.signal.aborted) {
-            const currentRun = await storage.getRun(run.id)
-            if (!currentRun || currentRun.status === 'cancelled') {
+            const latestRun = await storage.getRun(run.id)
+            if (!latestRun || latestRun.status === 'cancelled') {
               return
             }
           }
 
-          const failed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'failed')
-          if (!failed) {
-            return
+          // Check crash recovery: if ALL branches have completed results, skip the group
+          const allCompleted = branches.every((b) => completedMap.get(b.name)?.status === 'completed')
+          if (allCompleted) {
+            const merged: Record<string, PersistedValue> = {}
+            for (const branchDef of branches) {
+              const existing = completedMap.get(branchDef.name)
+              if (existing) {
+                merged[branchDef.name] = existing.output
+                stepsAccumulator[branchDef.name] = structuredClone(existing.output)
+              }
+            }
+            prev = merged
+            continue
+          }
+
+          // Not all completed — re-run the entire group
+          const frozenSteps = snapshotSteps(stepsAccumulator)
+
+          const groupAbort = new AbortController()
+          const onRunAbort = () => {
+            if (!groupAbort.signal.aborted) {
+              groupAbort.abort(activeRun.runAbortController.signal.reason)
+            }
+          }
+          if (activeRun.runAbortController.signal.aborted) {
+            groupAbort.abort(activeRun.runAbortController.signal.reason)
+          } else {
+            activeRun.runAbortController.signal.addEventListener('abort', onRunAbort, { once: true })
           }
 
           try {
-            hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: stepDef.name, error: err })
-          } catch { /* hooks must not affect engine state */ }
+            for (const branchDef of branches) {
+              try {
+                hooks?.onStepStart?.({ runId: run.id, stepName: branchDef.name })
+              } catch { /* hooks must not affect engine state */ }
+            }
 
-          if (wf.failureHandler) {
+            const groupActiveRun: ActiveRunState = {
+              ...activeRun,
+              runAbortController: groupAbort,
+            }
+
+            const results = await Promise.all(
+              branches.map(async (branchDef) => {
+                const guardedHandler: StepDefinition['handler'] = (ctx) => {
+                  const guardedComplete = (): never => {
+                    throw new ParallelCompleteError(branchDef.name)
+                  }
+                  return branchDef.handler({ ...ctx, complete: guardedComplete })
+                }
+
+                const guardedDef: StepDefinition = { ...branchDef, handler: guardedHandler }
+                const outcome = await executeStep(run, groupActiveRun, guardedDef, prev, frozenSteps)
+
+                if (outcome.kind === 'failed') {
+                  if (!groupAbort.signal.aborted) {
+                    groupAbort.abort(outcome.error)
+                  }
+                  throw new BranchFailedError(branchDef.name, outcome.error, outcome.attempts)
+                }
+
+                if (outcome.kind === 'early-complete') {
+                  const err = new ParallelCompleteError(branchDef.name)
+                  if (!groupAbort.signal.aborted) {
+                    groupAbort.abort(err)
+                  }
+                  throw new BranchFailedError(branchDef.name, err, outcome.attempts)
+                }
+
+                return { name: branchDef.name, output: outcome.output, attempts: outcome.attempts }
+              }),
+            )
+
+            // All branches succeeded — persist results
+            for (const result of results) {
+              const now = Date.now()
+              const saved = await storage.saveStepResult({
+                id: randomUUID(),
+                runId: run.id,
+                name: result.name,
+                status: 'completed',
+                output: result.output,
+                error: null,
+                attempts: result.attempts,
+                createdAt: now,
+                updatedAt: now,
+              }, run.leaseId)
+
+              if (!saved) {
+                throw new LeaseExpiredError(run.id)
+              }
+
+              try {
+                hooks?.onStepComplete?.({
+                  runId: run.id,
+                  stepName: result.name,
+                  output: result.output,
+                  attempts: result.attempts,
+                })
+              } catch { /* hooks must not affect engine state */ }
+
+              stepsAccumulator[result.name] = structuredClone(result.output)
+            }
+
+            const merged: Record<string, PersistedValue> = {}
+            for (const result of results) {
+              merged[result.name] = result.output
+            }
+            prev = merged
+          } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error))
+
+            if (err instanceof EarlyCompleteError) {
+              throw new Error('EarlyCompleteError escaped executeStep in parallel group')
+            }
+
+            if (err instanceof RunControlError) {
+              return
+            }
+
+            if (activeRun.runAbortController.signal.aborted) {
+              const currentRun = await storage.getRun(run.id)
+              if (!currentRun || currentRun.status === 'cancelled') {
+                return
+              }
+            }
+
+            const branchName = err instanceof BranchFailedError ? err.branchName : branches[0].name
+            const branchAttempts = err instanceof BranchFailedError ? err.attempts : 1
+            const branchError = err instanceof BranchFailedError ? err.branchError : err
+
+            // Persist the failed step result
+            const now = Date.now()
+            const saved = await storage.saveStepResult({
+              id: randomUUID(),
+              runId: run.id,
+              name: branchName,
+              status: 'failed',
+              output: null,
+              error: branchError.message,
+              attempts: branchAttempts,
+              createdAt: now,
+              updatedAt: now,
+            }, run.leaseId)
+
+            if (!saved) {
+              return
+            }
+
+            const failed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'failed')
+            if (!failed) {
+              return
+            }
+
             try {
-              await wf.failureHandler({
-                error: err,
-                stepName: stepDef.name,
-                input: run.input,
-              })
-            } catch { /* onFailure must not affect engine state */ }
-          }
+              hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: branchName, error: branchError })
+            } catch { /* hooks must not affect engine state */ }
 
-          return
+            if (wf.failureHandler) {
+              try {
+                await wf.failureHandler({
+                  error: branchError,
+                  stepName: branchName,
+                  input: run.input,
+                })
+              } catch { /* onFailure must not affect engine state */ }
+            }
+
+            return
+          } finally {
+            activeRun.runAbortController.signal.removeEventListener('abort', onRunAbort)
+          }
         }
       }
 
@@ -785,4 +967,16 @@ function deepFreeze<T extends Record<string, unknown>>(obj: T): T {
     }
   }
   return obj
+}
+
+/** Internal wrapper for carrying branch metadata through Promise.all rejections. */
+class BranchFailedError extends Error {
+  constructor(
+    public readonly branchName: string,
+    public readonly branchError: Error,
+    public readonly attempts: number,
+  ) {
+    super(branchError.message)
+    this.name = 'BranchFailedError'
+  }
 }

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -425,6 +425,13 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     let lastError: Error | null = null
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      // Bail out of further retry attempts once the run/group signal is aborted.
+      // A handler is not re-entered (runWithSignal short-circuits), but iterating
+      // the loop just to reject again wastes work and confuses metrics.
+      if (activeRun.runAbortController.signal.aborted) {
+        break
+      }
+
       const attemptSignal = createAttemptSignal(activeRun.runAbortController.signal, timeoutMs)
 
       try {
@@ -484,7 +491,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     branches: readonly StepDefinition[],
     prev: PersistedValue,
     stepsAccumulator: Record<string, PersistedValue>,
-    completedMap: Map<string, { status: string; output: PersistedValue; attempts: number }>,
+    completedMap: Map<string, { id: string; status: string; output: PersistedValue; attempts: number }>,
   ): Promise<ParallelGroupResult> {
     if (activeRun.runAbortController.signal.aborted) {
       const latestRun = await storage.getRun(run.id)
@@ -493,24 +500,31 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
       }
     }
 
-    // Crash recovery: if ALL branches have completed results, skip the group
-    const allCompleted = branches.every((b) => completedMap.get(b.name)?.status === 'completed')
-    if (allCompleted) {
-      const merged: Record<string, PersistedValue> = {}
-      for (const branchDef of branches) {
-        const existing = completedMap.get(branchDef.name)
-        if (existing) {
-          merged[branchDef.name] = existing.output
-          stepsAccumulator[branchDef.name] = structuredClone(existing.output)
-        }
+    // Crash-recovery: any branch already persisted as 'completed' is reused.
+    // Failed records do not count — they get retried fresh, matching sequential semantics.
+    const merged: Record<string, PersistedValue> = {}
+    const pendingBranches: StepDefinition[] = []
+    for (const branchDef of branches) {
+      const existing = completedMap.get(branchDef.name)
+      if (existing?.status === 'completed') {
+        merged[branchDef.name] = existing.output
+        stepsAccumulator[branchDef.name] = structuredClone(existing.output)
+      } else {
+        pendingBranches.push(branchDef)
       }
+    }
+
+    if (pendingBranches.length === 0) {
       return { kind: 'completed', merged }
     }
 
-    // Not all completed — re-run the entire group
     const frozenSteps = snapshotSteps(stepsAccumulator)
 
     const groupAbort = new AbortController()
+    // Track which branch was the *original* failure that caused the group to abort.
+    // Siblings that fail because they observed the abort are downstream effects, not
+    // the underlying cause — distinguishing this keeps onRunFailed accurate.
+    let causeBranch: BranchFailedError | null = null
     const onRunAbort = () => {
       if (!groupAbort.signal.aborted) {
         groupAbort.abort(activeRun.runAbortController.signal.reason)
@@ -523,7 +537,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     }
 
     try {
-      for (const branchDef of branches) {
+      for (const branchDef of pendingBranches) {
         try {
           hooks?.onStepStart?.({ runId: run.id, stepName: branchDef.name })
         } catch { /* hooks must not affect engine state */ }
@@ -534,8 +548,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         runAbortController: groupAbort,
       }
 
-      const results = await Promise.all(
-        branches.map(async (branchDef) => {
+      // Run all pending branches; collect both successes and failures so siblings
+      // get a chance to settle (allSettled, not all) before we tear down.
+      const settled = await Promise.allSettled(
+        pendingBranches.map(async (branchDef) => {
           const guardedHandler: StepDefinition['handler'] = (ctx) => {
             const guardedComplete = (): never => {
               throw new ParallelCompleteError(branchDef.name)
@@ -547,36 +563,95 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           const outcome = await executeStep(run, groupActiveRun, guardedDef, prev, frozenSteps)
 
           if (outcome.kind === 'failed') {
+            const failure = new BranchFailedError(branchDef.name, outcome.error, outcome.attempts)
             if (!groupAbort.signal.aborted) {
+              causeBranch = failure
               groupAbort.abort(outcome.error)
             }
-            throw new BranchFailedError(branchDef.name, outcome.error, outcome.attempts)
+            throw failure
           }
 
           if (outcome.kind === 'early-complete') {
             const err = new ParallelCompleteError(branchDef.name)
+            const failure = new BranchFailedError(branchDef.name, err, outcome.attempts)
             if (!groupAbort.signal.aborted) {
+              causeBranch = failure
               groupAbort.abort(err)
             }
-            throw new BranchFailedError(branchDef.name, err, outcome.attempts)
+            throw failure
           }
 
           return { name: branchDef.name, output: outcome.output, attempts: outcome.attempts }
         }),
       )
 
-      // All branches succeeded — persist results
-      const merged: Record<string, PersistedValue> = {}
-      for (const result of results) {
+      // If the run itself was cancelled while branches were running, surface that
+      // before reporting branch failures. Cancellation isn't a branch failure.
+      if (activeRun.runAbortController.signal.aborted) {
+        const currentRun = await storage.getRun(run.id)
+        if (!currentRun || currentRun.status === 'cancelled') {
+          return { kind: 'skipped-cancelled' }
+        }
+      }
+
+      // Prefer the branch that actually caused the abort; only fall back to scanning
+      // settled when no cause was recorded (e.g. group aborted from outside the loop).
+      let firstFailure: BranchFailedError | null = causeBranch
+      if (!firstFailure) {
+        for (const result of settled) {
+          if (result.status === 'rejected') {
+            const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason))
+            if (err instanceof RunControlError) {
+              return { kind: 'skipped-cancelled' }
+            }
+            if (err instanceof BranchFailedError) {
+              firstFailure = err
+              break
+            }
+            // Defensive: wrap unknown error as branch failure on first pending branch.
+            firstFailure = new BranchFailedError(pendingBranches[0].name, err, 1)
+            break
+          }
+        }
+      }
+
+      if (firstFailure) {
+        // Persist the failed step result. Reuse the existing row id so a retry upserts
+        // in place rather than appending a duplicate. If the lease is lost mid-write,
+        // we still report the failure — the outer code will no-op the run-status
+        // update because the same lease check will fail there.
+        const failedBranch = firstFailure.branchName
+        const existingRow = completedMap.get(failedBranch)
+        const now = Date.now()
+        await storage.saveStepResult({
+          id: existingRow?.id ?? randomUUID(),
+          runId: run.id,
+          name: failedBranch,
+          status: 'failed',
+          output: null,
+          error: firstFailure.branchError.message,
+          attempts: firstFailure.attempts,
+          createdAt: now,
+          updatedAt: now,
+        }, run.leaseId)
+
+        return { kind: 'failed', branchName: failedBranch, error: firstFailure.branchError }
+      }
+
+      // All pending branches succeeded — persist their results and fire complete hooks.
+      for (const result of settled) {
+        if (result.status !== 'fulfilled') continue
+        const branchResult = result.value
+        const existingRow = completedMap.get(branchResult.name)
         const now = Date.now()
         const saved = await storage.saveStepResult({
-          id: randomUUID(),
+          id: existingRow?.id ?? randomUUID(),
           runId: run.id,
-          name: result.name,
+          name: branchResult.name,
           status: 'completed',
-          output: result.output,
+          output: branchResult.output,
           error: null,
-          attempts: result.attempts,
+          attempts: branchResult.attempts,
           createdAt: now,
           updatedAt: now,
         }, run.leaseId)
@@ -588,18 +663,21 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         try {
           hooks?.onStepComplete?.({
             runId: run.id,
-            stepName: result.name,
-            output: result.output,
-            attempts: result.attempts,
+            stepName: branchResult.name,
+            output: branchResult.output,
+            attempts: branchResult.attempts,
           })
         } catch { /* hooks must not affect engine state */ }
 
-        stepsAccumulator[result.name] = structuredClone(result.output)
-        merged[result.name] = result.output
+        stepsAccumulator[branchResult.name] = structuredClone(branchResult.output)
+        merged[branchResult.name] = branchResult.output
       }
 
       return { kind: 'completed', merged }
     } catch (error) {
+      // The Promise.allSettled branch above swallows per-branch failures, so this
+      // catch only fires for LeaseExpiredError thrown during success-path persistence
+      // or other unexpected throws.
       const err = error instanceof Error ? error : new Error(String(error))
 
       if (err instanceof EarlyCompleteError) {
@@ -617,33 +695,14 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         }
       }
 
-      const branchName = err instanceof BranchFailedError ? err.branchName : branches[0].name
-      const branchAttempts = err instanceof BranchFailedError ? err.attempts : 1
-      const branchError = err instanceof BranchFailedError ? err.branchError : err
-
-      // Persist the failed step result
-      const now = Date.now()
-      const saved = await storage.saveStepResult({
-        id: randomUUID(),
-        runId: run.id,
-        name: branchName,
-        status: 'failed',
-        output: null,
-        error: branchError.message,
-        attempts: branchAttempts,
-        createdAt: now,
-        updatedAt: now,
-      }, run.leaseId)
-
-      if (!saved) {
-        return { kind: 'failed', branchName, error: branchError }
-      }
-
-      return { kind: 'failed', branchName, error: branchError }
+      // LeaseExpiredError or similar — surface as failure on the first pending branch
+      // (we don't have specific branch context here).
+      return { kind: 'failed', branchName: pendingBranches[0].name, error: err }
     } finally {
       activeRun.runAbortController.signal.removeEventListener('abort', onRunAbort)
     }
   }
+
 
   async function cancel(runId: string): Promise<boolean> {
     const run = await storage.getRun(runId)

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -473,10 +473,8 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
       }
     }
 
-    if (lastError instanceof RunControlError) {
-      throw lastError
-    }
-
+    // RunControlError is rethrown inside the loop; if we reach here, lastError is a
+    // regular failure (or null when the signal was aborted before any attempt ran).
     return { kind: 'failed', error: lastError ?? new Error('Unknown error'), attempts: maxAttempts }
   }
 
@@ -562,21 +560,14 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           const guardedDef: StepDefinition = { ...branchDef, handler: guardedHandler }
           const outcome = await executeStep(run, groupActiveRun, guardedDef, prev, frozenSteps)
 
+          // `outcome.kind === 'early-complete'` is unreachable: guardedComplete throws
+          // ParallelCompleteError (a regular error) before EarlyCompleteError can be
+          // raised, so executeStep returns 'completed' or 'failed' for parallel branches.
           if (outcome.kind === 'failed') {
             const failure = new BranchFailedError(branchDef.name, outcome.error, outcome.attempts)
             if (!groupAbort.signal.aborted) {
               causeBranch = failure
               groupAbort.abort(outcome.error)
-            }
-            throw failure
-          }
-
-          if (outcome.kind === 'early-complete') {
-            const err = new ParallelCompleteError(branchDef.name)
-            const failure = new BranchFailedError(branchDef.name, err, outcome.attempts)
-            if (!groupAbort.signal.aborted) {
-              causeBranch = failure
-              groupAbort.abort(err)
             }
             throw failure
           }
@@ -675,28 +666,14 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
       return { kind: 'completed', merged }
     } catch (error) {
-      // The Promise.allSettled branch above swallows per-branch failures, so this
-      // catch only fires for LeaseExpiredError thrown during success-path persistence
-      // or other unexpected throws.
+      // Promise.allSettled above swallows per-branch failures, so this catch only
+      // fires for LeaseExpiredError thrown during success-path persistence.
       const err = error instanceof Error ? error : new Error(String(error))
-
-      if (err instanceof EarlyCompleteError) {
-        throw new Error('EarlyCompleteError escaped executeStep in parallel group')
-      }
 
       if (err instanceof RunControlError) {
         return { kind: 'skipped-cancelled' }
       }
 
-      if (activeRun.runAbortController.signal.aborted) {
-        const currentRun = await storage.getRun(run.id)
-        if (!currentRun || currentRun.status === 'cancelled') {
-          return { kind: 'skipped-cancelled' }
-        }
-      }
-
-      // LeaseExpiredError or similar — surface as failure on the first pending branch
-      // (we don't have specific branch context here).
       return { kind: 'failed', branchName: pendingBranches[0].name, error: err }
     } finally {
       activeRun.runAbortController.signal.removeEventListener('abort', onRunAbort)

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -64,6 +64,14 @@ export class DuplicateStepError extends ReflowError {
   }
 }
 
+/** Thrown when `complete()` is called inside a parallel step handler. */
+export class ParallelCompleteError extends ReflowError {
+  constructor(public readonly stepName: string) {
+    super(`complete() cannot be called inside parallel step "${stepName}"`)
+    this.name = 'ParallelCompleteError'
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Input validation
 // ---------------------------------------------------------------------------

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -28,6 +28,11 @@ export interface StepDefinition {
   timeoutMs?: number
 }
 
+/** A single execution unit: either a sequential step or a parallel group. */
+export type ExecutionUnit =
+  | { readonly kind: 'step'; readonly definition: StepDefinition }
+  | { readonly kind: 'parallel'; readonly branches: readonly StepDefinition[] }
+
 /** Configuration object form for `.step()` when you need retry or timeout options. */
 export interface StepConfig<
   TInput extends PersistedValue,
@@ -67,7 +72,7 @@ export interface Workflow<
 > {
   readonly name: TName
   readonly inputSchema: StandardSchemaV1<TInput>
-  readonly steps: readonly StepDefinition[]
+  readonly executionUnits: readonly ExecutionUnit[]
   readonly failureHandler?: (ctx: FailureContext<TInput>) => Promise<void>
 
   step<TStepName extends string, TOutput extends PersistedValue | void>(
@@ -136,6 +141,20 @@ export function createWorkflow<TName extends string, TInput extends PersistedVal
   return buildWorkflow(config.name, config.input, [])
 }
 
+function getAllStepNames(units: readonly ExecutionUnit[]): Set<string> {
+  const names = new Set<string>()
+  for (const unit of units) {
+    if (unit.kind === 'step') {
+      names.add(unit.definition.name)
+    } else {
+      for (const branch of unit.branches) {
+        names.add(branch.name)
+      }
+    }
+  }
+  return names
+}
+
 function buildWorkflow<
   TName extends string,
   TInput extends PersistedValue,
@@ -144,13 +163,13 @@ function buildWorkflow<
 >(
   name: TName,
   inputSchema: StandardSchemaV1<TInput>,
-  steps: StepDefinition[],
+  executionUnits: ExecutionUnit[],
   failureHandler?: (ctx: FailureContext<TInput>) => Promise<void>,
 ): Workflow<TName, TInput, TPrev, TSteps> {
   return {
     name,
     inputSchema,
-    steps,
+    executionUnits,
     failureHandler,
 
     step<TStepName extends string, TOutput extends PersistedValue | void>(
@@ -164,7 +183,7 @@ function buildWorkflow<
       NormalizeOutput<TOutput>,
       TSteps & Record<TStepName, NormalizeOutput<TOutput>>
     > {
-      if (steps.some((step) => step.name === stepName)) {
+      if (getAllStepNames(executionUnits).has(stepName)) {
         throw new DuplicateStepError(name, stepName)
       }
 
@@ -187,7 +206,7 @@ function buildWorkflow<
       >(
         name,
         inputSchema,
-        [...steps, newStep],
+        [...executionUnits, { kind: 'step', definition: newStep }],
         failureHandler,
       )
     },
@@ -195,7 +214,7 @@ function buildWorkflow<
     onFailure(
       handler: (ctx: FailureContext<TInput>) => Promise<void>,
     ): Workflow<TName, TInput, TPrev, TSteps> {
-      return buildWorkflow(name, inputSchema, steps, handler)
+      return buildWorkflow(name, inputSchema, executionUnits, handler)
     },
 
     parseInput(input: unknown): TInput {

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import { DuplicateStepError, ValidationError } from './errors'
+import { ConfigError, DuplicateStepError, ValidationError } from './errors'
 import type { PersistedValue, RetryConfig } from './types'
 
 /** Context passed to every step handler. */
@@ -46,6 +46,22 @@ export interface StepConfig<
   handler: (ctx: StepContext<TInput, TPrev, TStepsSoFar>) => Promise<TOutput>
 }
 
+/** A parallel branch: either a bare handler or a StepConfig with retry/timeout. */
+export type ParallelBranch<
+  TInput extends PersistedValue,
+  TPrev extends PersistedValue,
+  TOutput extends PersistedValue | void = PersistedValue | void,
+  TStepsSoFar extends Record<string, PersistedValue> = Record<string, PersistedValue>,
+> =
+  | ((ctx: StepContext<TInput, TPrev, TStepsSoFar>) => Promise<TOutput>)
+  | StepConfig<TInput, TPrev, TOutput, TStepsSoFar>
+
+/** Extract the output type from a ParallelBranch. */
+export type InferBranchOutput<B> =
+  B extends (ctx: never) => Promise<infer O> ? O :
+  B extends { handler: (ctx: never) => Promise<infer O> } ? O :
+  never
+
 /** Context passed to the `onFailure` handler when a workflow run fails. */
 export interface FailureContext<TInput extends PersistedValue = PersistedValue> {
   /** The error that caused the failure. */
@@ -84,6 +100,15 @@ export interface Workflow<
     name: TStepName,
     config: StepConfig<TInput, TPrev, TOutput, TSteps>,
   ): Workflow<TName, TInput, NormalizeOutput<TOutput>, TSteps & Record<TStepName, NormalizeOutput<TOutput>>>
+
+  parallel<TBranches extends Record<string, ParallelBranch<TInput, TPrev, PersistedValue | void, TSteps>>>(
+    branches: TBranches,
+  ): Workflow<
+    TName,
+    TInput,
+    Prettify<{ [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }>,
+    TSteps & { [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }
+  >
 
   onFailure(
     handler: (ctx: FailureContext<TInput>) => Promise<void>,
@@ -207,6 +232,56 @@ function buildWorkflow<
         name,
         inputSchema,
         [...executionUnits, { kind: 'step', definition: newStep }],
+        failureHandler,
+      )
+    },
+
+    parallel<TBranches extends Record<string, ParallelBranch<TInput, TPrev, PersistedValue | void, TSteps>>>(
+      branches: TBranches,
+    ): Workflow<
+      TName,
+      TInput,
+      Prettify<{ [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }>,
+      TSteps & { [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }
+    > {
+      const branchEntries = Object.entries(branches)
+      if (branchEntries.length === 0) {
+        throw new ConfigError('parallel() requires at least one branch')
+      }
+
+      const existingNames = getAllStepNames(executionUnits)
+      for (const [branchName] of branchEntries) {
+        if (existingNames.has(branchName)) {
+          throw new DuplicateStepError(name, branchName)
+        }
+      }
+
+      const branchDefs: StepDefinition[] = branchEntries.map(([branchName, handlerOrConfig]) => {
+        if (typeof handlerOrConfig === 'object' && handlerOrConfig !== null && 'handler' in handlerOrConfig) {
+          return {
+            name: branchName,
+            handler: handlerOrConfig.handler as unknown as StepDefinition['handler'],
+            retry: handlerOrConfig.retry,
+            timeoutMs: handlerOrConfig.timeoutMs,
+          }
+        }
+        return {
+          name: branchName,
+          handler: handlerOrConfig as unknown as StepDefinition['handler'],
+          retry: undefined,
+          timeoutMs: undefined,
+        }
+      })
+
+      return buildWorkflow<
+        TName,
+        TInput,
+        Prettify<{ [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }>,
+        TSteps & { [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }
+      >(
+        name,
+        inputSchema,
+        [...executionUnits, { kind: 'parallel', branches: branchDefs }],
         failureHandler,
       )
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   WorkflowNotFoundError,
   DuplicateWorkflowError,
   DuplicateStepError,
+  ParallelCompleteError,
   ValidationError,
   IdempotencyConflictError,
   SerializationError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export type {
   StepContext,
   StepDefinition,
   StepConfig,
+  ParallelBranch,
+  InferBranchOutput,
   FailureContext,
   InferInput,
   InferSteps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type { ValidationIssue } from './core/errors'
 export type {
   Workflow,
   AnyWorkflow,
+  ExecutionUnit,
   StepContext,
   StepDefinition,
   StepConfig,


### PR DESCRIPTION
## Summary

- Adds `workflow.parallel({ branchName: handler | config, ... })` for running independent steps concurrently. The next step's `prev` is a typed merged record of all branch outputs.
- Per-branch retry and timeout config, fail-fast on first branch failure, per-branch crash recovery (completed branches are skipped on resume — no duplicated side effects), and cause-aware failure reporting (`onRunFailed` / `onFailure` surface the branch that *caused* the abort, not a sibling aborted by signal propagation).
- New `ParallelCompleteError` thrown if a branch calls `complete()`.

This closes #20, originally suggested by @brianjenkins94. Thanks again Brian — three of the last four feature ideas have come from you.

## Design note — and a question for @brianjenkins94

Your issue referenced GitHub Actions' `needs:` model, which is an arbitrary DAG. I went with a structured `.parallel()` group instead. Reasoning:

- Preserves type narrowing on `prev` (a free-form DAG breaks that — what's the prev type when multiple disjoint paths could precede a step?).
- Matches Reflow's linear-builder philosophy.
- Avoids topological sort, cycle detection, and merge-policy decisions.
- Covers fan-out / fan-in cleanly: `A → (B, C, D) → E`, which is ~90% of the "parallel" use cases I could think of.

What it *cannot* express that `needs:` could:

- Non-rectangular DAGs (e.g. `D` depends only on `A`, runs alongside an independent `B → C` chain).
- Skip-level dependencies.

**Does `.parallel()` cover your actual workload?** If you have a case in mind that genuinely needs arbitrary-DAG expressiveness, I'd rather know now than ship `.parallel()` and have it not fit. Happy to revisit the design before merging.

## What's in the diff

- `src/core/workflow.ts` — `.parallel()` builder, `ExecutionUnit` model.
- `src/core/engine.ts` — `executeParallelGroup`, per-branch resume, `Promise.allSettled`, cause-tracking, abort-aware retry bail.
- `src/core/__tests__/parallel-engine.test.ts` — 25 tests covering builder, types, fail-fast, retries, timeouts, hooks, crash recovery, cancellation, sequential parallel groups.
- `examples/4-parallel-enrichment.ts` — runnable fan-out/fan-in example.
- `README.md`, `docs/docs.html`, `docs/llms.txt` — new "Parallel Steps" section + API reference.
- `CHANGELOG.md` — entry under `0.4.0`.

## Test plan

- [x] `bun run test` — 291/291 pass
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] `oxlint` — clean
- [x] `npx tsx examples/4-parallel-enrichment.ts` — runs end-to-end in ~1.2s (vs ~3.2s sequential)