### PR TITLE
feat: engine.stream() + async hooks (closes #24, #23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,43 @@ jobs:
       - run: bun run typecheck
       - run: bun run test -- --coverage
       - run: bun run build
+
+  node-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: bun install
+      - run: bun run build
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 18.18.0
+      - name: Smoke test minimum Node version
+        run: |
+          node --input-type=module <<'EOF'
+          import { createEngine } from './dist/index.mjs'
+
+          if (typeof Symbol.asyncDispose !== 'symbol') {
+            throw new Error('Symbol.asyncDispose is unavailable')
+          }
+
+          const storage = {
+            initialize: async () => {},
+            createRun: async () => { throw new Error('not used') },
+            claimNextRun: async () => null,
+            heartbeatRun: async () => true,
+            getRun: async () => null,
+            getStepResults: async () => [],
+            saveStepResult: async () => true,
+            updateRunStatus: async () => true,
+            updateClaimedRunStatus: async () => true,
+            close: () => {},
+          }
+          const engine = createEngine({ storage, workflows: [] })
+          const stream = engine.stream()
+
+          if (typeof stream[Symbol.asyncDispose] !== 'function') {
+            throw new Error('ResultStream is not AsyncDisposable')
+          }
+          await stream[Symbol.asyncDispose]()
+          EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Hook event objects are now aligned with `EngineEvent`: every event carries a `type` discriminator and the owning `workflow` name, `onStepStart` / `onStepComplete` now include `workflow`, and `onRunComplete` now includes the workflow's final `output`. These are additive — existing hook callbacks continue to type-check and run unchanged.
+- The minimum supported Node.js version is now 18.18, the first Node 18 release with `Symbol.asyncDispose` support.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.0
+
+### Added
+
+- **`engine.stream()`** — a pull-based, backpressure-aware stream of execution events. Returns an `AsyncIterableIterator<EngineEvent>` (also an `AsyncDisposable`) so you can `for await` over `runStart` / `stepStart` / `stepComplete` / `runComplete` / `runFailed` events instead of wiring up callback-to-queue plumbing. Optional `bufferSize` paces the engine against a slow consumer; breaking out of the loop, `await using`, or `engine.stop()` unsubscribes automatically. New exported types: `EngineEvent`, `EngineEventOf`, `StreamOptions`, `ResultStream`. ([#24](https://github.com/danfry1/reflow-ts/issues/24) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
+- **Async hooks** — lifecycle hooks may now be `async` and are awaited before the engine proceeds, so a hook can flush a metric, persist an audit row, or apply backpressure with ordering guarantees. A throwing or rejecting hook is still fully contained and never affects engine state. ([#23](https://github.com/danfry1/reflow-ts/issues/23) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
+
+### Changed
+
+- Hook event objects are now aligned with `EngineEvent`: every event carries a `type` discriminator and the owning `workflow` name, `onStepStart` / `onStepComplete` now include `workflow`, and `onRunComplete` now includes the workflow's final `output`. These are additive — existing hook callbacks continue to type-check and run unchanged.
+
 ## 0.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -338,10 +338,13 @@ const engine = createEngine({
   storage,
   workflows: [orderWorkflow],
   hooks: {
-    onStepComplete: ({ runId, stepName, output, attempts }) => {
+    onRunStart: ({ runId, workflow }) => { /* ... */ },
+    onStepStart: ({ runId, workflow, stepName }) => { /* ... */ },
+    onStepComplete: ({ runId, workflow, stepName, output, attempts }) => {
       console.log(`Step ${stepName} completed in ${attempts} attempt(s)`)
     },
-    onRunComplete: ({ runId, workflow }) => {
+    onRunComplete: ({ runId, workflow, output }) => {
+      // `output` is the workflow's final result
       metrics.increment('workflow.completed', { workflow })
     },
     onRunFailed: ({ runId, workflow, stepName, error }) => {
@@ -354,6 +357,48 @@ const engine = createEngine({
   },
 })
 ```
+
+Hooks may be **synchronous or `async`**. An async hook is awaited before the engine
+moves on, so you can use it to flush a metric, persist an audit row, or apply
+backpressure. A hook that throws (or rejects) never affects engine state — the error
+is swallowed so a broken observer can't fail a workflow.
+
+### Streaming Results
+
+Hooks are push-based callbacks. When you'd rather **pull** results — to apply
+backpressure, rate-limit, or pipe completions into a producer/consumer loop — use
+`engine.stream()`. It returns an async iterable of [`EngineEvent`](#api-reference)s:
+
+```typescript
+const engine = createEngine({ storage, workflows: [importWorkflow] })
+await engine.start()
+
+for await (const event of engine.stream()) {
+  if (event.type === 'runComplete') {
+    await pipeline.push(event.output) // process each result as it lands
+  }
+}
+```
+
+Each call to `engine.stream()` returns an independent stream. The event is a
+discriminated union (`runStart`, `stepStart`, `stepComplete`, `runComplete`,
+`runFailed`), so TypeScript narrows `event.output`, `event.error`, etc. once you
+check `event.type`.
+
+**Backpressure.** By default the stream buffers without bound and never slows the
+engine. Pass `bufferSize` to pace the engine against a slow consumer — the engine
+pauses once the buffer is full and resumes as you pull:
+
+```typescript
+// The engine won't start the next unit of work until you consume the last one.
+for await (const event of engine.stream({ bufferSize: 1 })) {
+  await slowlyHandle(event)
+}
+```
+
+**Cleanup is automatic.** Breaking out of the loop (or `await using stream = engine.stream()`)
+unsubscribes from the engine, and `engine.stop()` ends every open stream so consumer
+loops terminate cleanly.
 
 ### Step Timeouts
 
@@ -680,7 +725,7 @@ Creates an engine that executes workflows.
 |---|---|---|---|
 | `config.storage` | `StorageAdapter` | required | Storage backend |
 | `config.workflows` | `Workflow[]` | required | Workflows to register |
-| `config.hooks` | `EngineHooks` | `undefined` | Lifecycle hooks (`onStepComplete`, `onRunComplete`, `onRunFailed`, `onError`) |
+| `config.hooks` | `EngineHooks` | `undefined` | Lifecycle hooks (`onRunStart`, `onStepStart`, `onStepComplete`, `onRunComplete`, `onRunFailed`, `onError`). May be sync or `async` (awaited) |
 | `config.concurrency` | `number` | `1` | Number of runs to process in parallel per tick |
 | `config.runLeaseDurationMs` | `number` | `30000` | How long a claimed run stays `running` before another engine may reclaim it |
 | `config.heartbeatIntervalMs` | `number` | `leaseDuration / 3` | How often the active worker renews its lease |
@@ -698,6 +743,16 @@ Stops the polling loop, clears all schedules, and waits for any in-flight tick t
 ### `engine.tick()`
 
 Claims up to `concurrency` pending or stale runs and executes them in parallel. Useful for CLI tools or tests where you want explicit control instead of polling. If you use `tick()` without `start()`, call `storage.initialize()` first.
+
+### `engine.stream(options?)`
+
+Returns a pull-based `ResultStream` — an `AsyncIterableIterator<EngineEvent>` (and `AsyncDisposable`) of execution events. Each call returns an independent stream; iterate it with `for await`. `EngineEvent` is a discriminated union on `type`: `runStart`, `stepStart`, `stepComplete` (`{ output, attempts }`), `runComplete` (`{ output }`), and `runFailed` (`{ stepName, error }`) — all carrying `runId` and `workflow`.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `bufferSize` | `number` | `Infinity` | Max events buffered before the engine pauses (backpressure). Set to a finite value (e.g. `1`) to pace the engine against a slow consumer |
+
+Breaking out of the loop, disposing via `await using`, or calling `engine.stop()` unsubscribes the stream automatically.
 
 ### `engine.enqueue(name, input, options?)`
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ bun add reflow-ts
 npm install reflow-ts better-sqlite3
 ```
 
+Node.js 18.18 or newer is required.
+
 Then pick a storage adapter based on your runtime:
 
 ```typescript
@@ -750,7 +752,7 @@ Returns a pull-based `ResultStream` — an `AsyncIterableIterator<EngineEvent>` 
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `bufferSize` | `number` | `Infinity` | Max events buffered before the engine pauses (backpressure). Set to a finite value (e.g. `1`) to pace the engine against a slow consumer |
+| `bufferSize` | `number` | `Infinity` | Max events buffered before the engine pauses (backpressure). Set to `0` for strict rendezvous delivery, or another non-negative integer to allow that many buffered events |
 
 Breaking out of the loop, disposing via `await using`, or calling `engine.stop()` unsubscribes the stream automatically.
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -58,6 +58,7 @@
             <a href="#scheduled-workflows">Scheduled Workflows</a>
             <a href="#step-timeouts">Step Timeouts</a>
             <a href="#hooks">Hooks</a>
+            <a href="#streaming">Streaming Results</a>
             <a href="#storage">Storage</a>
             <a href="#deployment">Deployment</a>
 
@@ -75,6 +76,7 @@
             <a href="#api-engine-start">engine.start</a>
             <a href="#api-engine-stop">engine.stop</a>
             <a href="#api-engine-tick">engine.tick</a>
+            <a href="#api-engine-stream">engine.stream</a>
             <a href="#api-engine-enqueue">engine.enqueue</a>
             <a href="#api-engine-cancel">engine.cancel</a>
             <a href="#api-engine-schedule">engine.schedule</a>
@@ -549,10 +551,13 @@ engine.unschedule(scheduleId)
   storage,
   workflows: [orderWorkflow],
   hooks: {
-    onStepComplete: ({ runId, stepName, output, attempts }) => {
+    onRunStart: ({ runId, workflow }) => {},
+    onStepStart: ({ runId, workflow, stepName }) => {},
+    onStepComplete: ({ runId, workflow, stepName, output, attempts }) => {
       console.log(stepName + ' completed in ' + attempts + ' attempt(s)')
     },
-    onRunComplete: ({ runId, workflow }) => {
+    onRunComplete: ({ runId, workflow, output }) => {
+      // output is the workflow's final result
       metrics.increment('workflow.completed', { workflow })
     },
     onRunFailed: ({ runId, workflow, stepName, error }) => {
@@ -564,6 +569,30 @@ engine.unschedule(scheduleId)
     },
   },
 })</code></pre>
+
+          <p>Hooks may be synchronous or <code>async</code>. An async hook is awaited before the engine moves on, so it can flush a metric, persist an audit row, or apply backpressure. A hook that throws or rejects never affects engine state &mdash; the error is swallowed.</p>
+
+          <!-- Streaming Results -->
+          <h2 id="streaming">Streaming Results</h2>
+
+          <p>Hooks are push-based callbacks. When you'd rather <strong>pull</strong> results &mdash; to apply backpressure, rate-limit, or feed a producer/consumer loop &mdash; use <code>engine.stream()</code>. It returns an async iterable of <code>EngineEvent</code>s:</p>
+
+          <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false"><code>for await (const event of engine.stream()) {
+  if (event.type === 'runComplete') {
+    await pipeline.push(event.output) // process each result as it lands
+  }
+}</code></pre>
+
+          <p>Each call returns an independent stream. <code>EngineEvent</code> is a discriminated union (<code>runStart</code>, <code>stepStart</code>, <code>stepComplete</code>, <code>runComplete</code>, <code>runFailed</code>), so TypeScript narrows <code>event.output</code>, <code>event.error</code>, etc. once you check <code>event.type</code>.</p>
+
+          <p><strong>Backpressure.</strong> By default the stream buffers without bound and never slows the engine. Pass <code>bufferSize</code> to pace the engine against a slow consumer &mdash; it pauses once the buffer is full and resumes as you pull:</p>
+
+          <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false"><code>// The engine won't start the next unit of work until you consume the last one.
+for await (const event of engine.stream({ bufferSize: 1 })) {
+  await slowlyHandle(event)
+}</code></pre>
+
+          <p><strong>Cleanup is automatic.</strong> Breaking out of the loop (or <code>await using stream = engine.stream()</code>) unsubscribes from the engine, and <code>engine.stop()</code> ends every open stream so consumer loops terminate cleanly.</p>
 
           <!-- Storage -->
           <h2 id="storage">Storage</h2>
@@ -907,7 +936,7 @@ workflow.step('x', async ({ prev }) => {
                 <div class="api-param">
                   <span class="api-param-name">hooks</span>
                   <span class="api-param-type">EngineHooks</span>
-                  <span class="api-param-desc">Lifecycle hooks: <code>onStepComplete</code>, <code>onRunComplete</code>, <code>onRunFailed</code>, <code>onError</code></span>
+                  <span class="api-param-desc">Lifecycle hooks: <code>onRunStart</code>, <code>onStepStart</code>, <code>onStepComplete</code>, <code>onRunComplete</code>, <code>onRunFailed</code>, <code>onError</code>. May be sync or <code>async</code> (awaited)</span>
                 </div>
                 <div class="api-param">
                   <span class="api-param-name">concurrency</span>
@@ -960,6 +989,25 @@ workflow.step('x', async ({ prev }) => {
               </div>
               <p>Claims up to <code>concurrency</code> pending or stale runs and executes them in parallel. Useful for CLI tools or tests where you want explicit control instead of polling.</p>
               <div class="api-returns">Returns <code>Promise&lt;void&gt;</code></div>
+            </div>
+
+            <div class="api-card" id="api-engine-stream">
+              <div class="api-header">
+                <h3>engine.stream(options?)</h3>
+              </div>
+              <p>Returns a pull-based <code>ResultStream</code> &mdash; an <code>AsyncIterableIterator&lt;EngineEvent&gt;</code> (and <code>AsyncDisposable</code>) of execution events. Each call returns an independent stream; iterate it with <code>for await</code>. <code>EngineEvent</code> is a discriminated union on <code>type</code>: <code>runStart</code>, <code>stepStart</code>, <code>stepComplete</code> (<code>{ output, attempts }</code>), <code>runComplete</code> (<code>{ output }</code>), <code>runFailed</code> (<code>{ stepName, error }</code>) &mdash; all carrying <code>runId</code> and <code>workflow</code>.</p>
+              <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false" data-compact="true"><code>for await (const event of engine.stream()) {
+  if (event.type === 'runComplete') await pipeline.push(event.output)
+}</code></pre>
+              <div class="api-params">
+                <p class="api-params-label">Options</p>
+                <div class="api-param">
+                  <span class="api-param-name">bufferSize</span>
+                  <span class="api-param-type">number</span>
+                  <span class="api-param-desc">Max events buffered before the engine pauses (backpressure). Default: <code>Infinity</code>. Set to a finite value (e.g. <code>1</code>) to pace the engine against a slow consumer</span>
+                </div>
+              </div>
+              <div class="api-returns">Returns <code>ResultStream</code>. Breaking out of the loop, <code>await using</code>, or <code>engine.stop()</code> unsubscribes automatically.</div>
             </div>
 
             <div class="api-card" id="api-engine-enqueue">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -134,6 +134,8 @@ bun add reflow-ts
 # Node.js (requires better-sqlite3)
 npm install reflow-ts better-sqlite3</code></pre>
 
+          <p>Node.js 18.18 or newer is required.</p>
+
           <p>Then pick a storage adapter based on your runtime:</p>
 
           <pre class="code-block docs-code" data-language="typescript" data-line-numbers="false" data-compact="true"><code>// Bun - zero native deps
@@ -1004,7 +1006,7 @@ workflow.step('x', async ({ prev }) => {
                 <div class="api-param">
                   <span class="api-param-name">bufferSize</span>
                   <span class="api-param-type">number</span>
-                  <span class="api-param-desc">Max events buffered before the engine pauses (backpressure). Default: <code>Infinity</code>. Set to a finite value (e.g. <code>1</code>) to pace the engine against a slow consumer</span>
+                  <span class="api-param-desc">Max events buffered before the engine pauses (backpressure). Default: <code>Infinity</code>. Set to <code>0</code> for strict rendezvous delivery, or another non-negative integer to allow that many buffered events</span>
                 </div>
               </div>
               <div class="api-returns">Returns <code>ResultStream</code>. Breaking out of the loop, <code>await using</code>, or <code>engine.stop()</code> unsubscribes automatically.</div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -313,18 +313,42 @@ Step-level timeoutMs takes precedence over retry.timeoutMs.
 
 ### Hooks
 
+Lifecycle hooks may be synchronous or async (an async hook is awaited before the engine proceeds). A throwing/rejecting hook never affects engine state. Every event carries `type` and `workflow`.
+
 ```typescript
 const engine = createEngine({
   storage,
   workflows: [orderWorkflow],
   hooks: {
-    onStepComplete: ({ runId, stepName, output, attempts }) => { },
-    onRunComplete: ({ runId, workflow }) => { },
+    onRunStart: ({ runId, workflow }) => { },
+    onStepStart: ({ runId, workflow, stepName }) => { },
+    onStepComplete: ({ runId, workflow, stepName, output, attempts }) => { },
+    onRunComplete: ({ runId, workflow, output }) => { }, // output = final result
     onRunFailed: ({ runId, workflow, stepName, error }) => { },
     onError: (error) => { }, // background failures (scheduled enqueues, poll cycles)
   },
 })
 ```
+
+### Streaming Results
+
+`engine.stream(options?)` returns a pull-based AsyncIterableIterator<EngineEvent> (also AsyncDisposable). Use it to consume results with backpressure instead of push-based hooks. EngineEvent is a discriminated union on `type`: runStart, stepStart, stepComplete ({ output, attempts }), runComplete ({ output }), runFailed ({ stepName, error }) — all with runId and workflow.
+
+```typescript
+for await (const event of engine.stream()) {
+  if (event.type === 'runComplete') await pipeline.push(event.output)
+}
+```
+
+By default the buffer is unbounded (never slows the engine). Pass `bufferSize` to apply backpressure — the engine pauses once the buffer fills and resumes as the consumer pulls:
+
+```typescript
+for await (const event of engine.stream({ bufferSize: 1 })) {
+  await slowlyHandle(event) // engine waits for each item
+}
+```
+
+Breaking out of the loop, `await using stream = engine.stream()`, or `engine.stop()` unsubscribes the stream automatically.
 
 ### Storage
 
@@ -458,6 +482,11 @@ Stops polling loop, clears all schedules, and waits for any in-flight tick to fi
 ### engine.tick()
 
 Claims up to concurrency pending/stale runs and executes them in parallel. For CLI tools or tests.
+
+### engine.stream(options?)
+
+Returns a pull-based ResultStream — an AsyncIterableIterator<EngineEvent> and AsyncDisposable. Each call returns an independent stream. EngineEvent is a discriminated union on `type`: runStart, stepStart, stepComplete, runComplete, runFailed (all with runId, workflow).
+Option: bufferSize (number, default Infinity) - max events buffered before the engine pauses (backpressure). Breaking the loop / await using / engine.stop() unsubscribes.
 
 ### engine.enqueue(name, input, options?)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,6 +12,8 @@ bun add reflow-ts
 npm install reflow-ts better-sqlite3
 ```
 
+Node.js 18.18 or newer is required.
+
 Pick a storage adapter based on your runtime:
 
 ```typescript
@@ -486,7 +488,7 @@ Claims up to concurrency pending/stale runs and executes them in parallel. For C
 ### engine.stream(options?)
 
 Returns a pull-based ResultStream — an AsyncIterableIterator<EngineEvent> and AsyncDisposable. Each call returns an independent stream. EngineEvent is a discriminated union on `type`: runStart, stepStart, stepComplete, runComplete, runFailed (all with runId, workflow).
-Option: bufferSize (number, default Infinity) - max events buffered before the engine pauses (backpressure). Breaking the loop / await using / engine.stop() unsubscribes.
+Option: bufferSize (non-negative integer, default Infinity) - max events buffered before the engine pauses (backpressure). Set to 0 for strict rendezvous delivery. Breaking the loop / await using / engine.stop() unsubscribes.
 
 ### engine.enqueue(name, input, options?)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.18.0"
   },
   "exports": {
     ".": {

--- a/src/core/__tests__/async-iterator.test.ts
+++ b/src/core/__tests__/async-iterator.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createBoundedAsyncIterator } from '../async-iterator'
+
+describe('createBoundedAsyncIterator', () => {
+  it('supports undefined values without confusing them with an empty buffer', async () => {
+    const { iterator, subscriber } = createBoundedAsyncIterator<undefined>(1, () => {})
+    const controller = new AbortController()
+
+    await subscriber.push(undefined, controller.signal)
+
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: false })
+    await iterator.return?.()
+  })
+
+  it('implements zero-capacity rendezvous delivery', async () => {
+    const { iterator, subscriber } = createBoundedAsyncIterator<string>(0, () => {})
+    const controller = new AbortController()
+    let pushSettled = false
+    const pushPromise = subscriber.push('event', controller.signal).then(() => {
+      pushSettled = true
+    })
+
+    await Promise.resolve()
+    expect(pushSettled).toBe(false)
+    await expect(iterator.next()).resolves.toEqual({ value: 'event', done: false })
+    await pushPromise
+  })
+
+  it('removes an aborted producer without disturbing later queued producers', async () => {
+    const { iterator, subscriber } = createBoundedAsyncIterator<string>(1, () => {})
+    const active = new AbortController()
+    const aborted = new AbortController()
+    const later = new AbortController()
+
+    await subscriber.push('buffered', active.signal)
+    const abortedPush = subscriber.push('aborted', aborted.signal)
+    const laterPush = subscriber.push('later', later.signal)
+    aborted.abort(new Error('cancelled'))
+
+    await expect(abortedPush).rejects.toThrow('cancelled')
+    await expect(iterator.next()).resolves.toEqual({ value: 'buffered', done: false })
+    await laterPush
+    await expect(iterator.next()).resolves.toEqual({ value: 'later', done: false })
+  })
+
+  it('close() preserves accepted buffered values and drops blocked producers', async () => {
+    const { iterator, subscriber } = createBoundedAsyncIterator<string>(1, () => {})
+    const controller = new AbortController()
+
+    await subscriber.push('buffered', controller.signal)
+    const blockedPush = subscriber.push('blocked', controller.signal)
+    subscriber.close()
+
+    await blockedPush
+    await expect(iterator.next()).resolves.toEqual({ value: 'buffered', done: false })
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true })
+    await expect(subscriber.push('late', controller.signal)).resolves.toBeUndefined()
+  })
+
+  it('return() clears buffered values and invokes disposal exactly once', async () => {
+    const onDispose = vi.fn()
+    const { iterator, subscriber } = createBoundedAsyncIterator<string>(2, onDispose)
+    const controller = new AbortController()
+
+    await subscriber.push('a', controller.signal)
+    await subscriber.push('b', controller.signal)
+    await iterator.return?.()
+    await iterator.return?.()
+    await iterator[Symbol.asyncDispose]()
+
+    expect(onDispose).toHaveBeenCalledOnce()
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('rejects immediately when the producer signal is already aborted', async () => {
+    const { iterator, subscriber } = createBoundedAsyncIterator<string>(1, () => {})
+    const controller = new AbortController()
+    controller.abort(new Error('already cancelled'))
+
+    await expect(subscriber.push('event', controller.signal)).rejects.toThrow(
+      'already cancelled',
+    )
+    await iterator.return?.()
+  })
+
+  it('handles an abort racing with producer listener registration', async () => {
+    const { iterator, subscriber } = createBoundedAsyncIterator<string>(0, () => {})
+    const controller = new AbortController()
+    const signal = controller.signal
+    const addEventListener = signal.addEventListener.bind(signal)
+    vi.spyOn(signal, 'addEventListener').mockImplementation((type, listener, options) => {
+      addEventListener(type, listener, options)
+      controller.abort(new Error('registration race'))
+    })
+
+    await expect(subscriber.push('event', signal)).rejects.toThrow('registration race')
+    await iterator.return?.()
+  })
+})

--- a/src/core/__tests__/engine.test.ts
+++ b/src/core/__tests__/engine.test.ts
@@ -1118,8 +1118,10 @@ describe('Engine', () => {
 
       expect(onRunComplete).toHaveBeenCalledOnce()
       expect(onRunComplete).toHaveBeenCalledWith({
+        type: 'runComplete',
         runId: run.id,
         workflow: 'complete-hook',
+        output: { done: true },
       })
     })
 
@@ -1139,6 +1141,7 @@ describe('Engine', () => {
 
       expect(onRunFailed).toHaveBeenCalledOnce()
       expect(onRunFailed).toHaveBeenCalledWith({
+        type: 'runFailed',
         runId: run.id,
         workflow: 'fail-hook',
         stepName: 'broken',
@@ -1289,6 +1292,7 @@ describe('Engine', () => {
 
       expect(onRunStart).toHaveBeenCalledOnce()
       expect(onRunStart).toHaveBeenCalledWith({
+        type: 'runStart',
         runId: run.id,
         workflow: 'run-start-hook',
       })
@@ -1333,8 +1337,8 @@ describe('Engine', () => {
       await engine.tick()
 
       expect(onStepStart).toHaveBeenCalledTimes(2)
-      expect(onStepStart).toHaveBeenCalledWith({ runId: run.id, stepName: 'a' })
-      expect(onStepStart).toHaveBeenCalledWith({ runId: run.id, stepName: 'b' })
+      expect(onStepStart).toHaveBeenCalledWith({ type: 'stepStart', runId: run.id, workflow: 'step-start-hook', stepName: 'a' })
+      expect(onStepStart).toHaveBeenCalledWith({ type: 'stepStart', runId: run.id, workflow: 'step-start-hook', stepName: 'b' })
     })
 
     it('does not call onStepStart for already-completed steps on resume', async () => {
@@ -2074,7 +2078,7 @@ describe('Engine', () => {
       const run = await engine.enqueue('early-hook', {})
       await engine.tick()
 
-      expect(hookCalled).toHaveBeenCalledWith({ runId: run.id, workflow: 'early-hook' })
+      expect(hookCalled).toHaveBeenCalledWith({ type: 'runComplete', runId: run.id, workflow: 'early-hook', output: undefined })
     })
 
     it('complete() fires onStepComplete hook', async () => {
@@ -2091,7 +2095,9 @@ describe('Engine', () => {
       await engine.tick()
 
       expect(stepHook).toHaveBeenCalledWith({
+        type: 'stepComplete',
         runId: run.id,
+        workflow: 'early-step-hook',
         stepName: 'check',
         output: { done: true },
         attempts: 1,
@@ -2199,12 +2205,14 @@ describe('Engine', () => {
       expect(info.run.status).toBe('completed')
       expect(neverRuns).not.toHaveBeenCalled()
       expect(stepHook).toHaveBeenCalledWith({
+        type: 'stepComplete',
         runId: run.id,
+        workflow: 'early-recover',
         stepName: 'check',
         output: { done: true },
         attempts: 1,
       })
-      expect(runHook).toHaveBeenCalledWith({ runId: run.id, workflow: 'early-recover' })
+      expect(runHook).toHaveBeenCalledWith({ type: 'runComplete', runId: run.id, workflow: 'early-recover', output: { done: true } })
     })
   })
 })

--- a/src/core/__tests__/stream.test.ts
+++ b/src/core/__tests__/stream.test.ts
@@ -271,6 +271,47 @@ describe('engine.stream()', () => {
     expect(streamSawComplete).toBe(true)
   })
 
+  it('leaves a run reclaimable (not failed) when stopped while paused on backpressure', async () => {
+    const wf = createWorkflow({ name: 'stop-bp', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+      .step('b', async () => ({ y: 2 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    // A 1-event buffer with no consumer pauses the engine mid-run on backpressure.
+    const stream = engine.stream({ bufferSize: 1 })
+    void stream
+
+    const run = await engine.enqueue('stop-bp', {})
+    await engine.start(10_000)
+    await delay(50)
+    await engine.stop()
+
+    // A graceful stop must not mark the paused run failed — it stays 'running'
+    // so a future engine can reclaim it via stale-lease recovery.
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('running')
+  })
+
+  it('cancels (not fails) a run paused on backpressure', async () => {
+    const wf = createWorkflow({ name: 'cancel-bp', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+      .step('b', async () => ({ y: 2 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream({ bufferSize: 1 })
+    void stream
+
+    const run = await engine.enqueue('cancel-bp', {})
+    await engine.start(10_000)
+    await delay(50)
+
+    expect(await engine.cancel(run.id)).toBe(true)
+    await engine.stop() // closes the stream, unblocking the paused producer
+
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('cancelled')
+  })
+
   it('ends open streams when the engine stops', async () => {
     const wf = createWorkflow({ name: 'stop-stream', input: z.object({}) })
       .step('a', async () => ({ x: 1 }))
@@ -294,6 +335,20 @@ describe('engine.stream()', () => {
         throw new Error('stream did not close on engine stop')
       }),
     ])
+  })
+
+  it('resolves a pending next() as done when the stream is disposed', async () => {
+    const wf = createWorkflow({ name: 'pending-next', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    // next() on an empty buffer parks a consumer waiter; disposing must release it.
+    const pending = stream.next()
+    await stream.return?.()
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true })
   })
 
   it('supports await using for disposal', async () => {

--- a/src/core/__tests__/stream.test.ts
+++ b/src/core/__tests__/stream.test.ts
@@ -1,12 +1,70 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { z } from 'zod'
 import { createWorkflow } from '../workflow'
 import { createEngine } from '../engine'
 import type { EngineEvent } from '../engine'
+import type { StorageAdapter } from '../types'
 import { MemoryStorage } from '../../storage/memory'
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function deferred(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve!: () => void
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+async function settlesWithin<T>(promise: Promise<T>, timeoutMs = 500): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Promise did not settle within ${timeoutMs}ms`))
+    }, timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+function delaySecondClaim(
+  delegate: MemoryStorage,
+  secondClaimStarted: { resolve: () => void },
+  releaseSecondClaim: Promise<void>,
+): StorageAdapter {
+  let claimCalls = 0
+  return {
+    initialize: () => delegate.initialize(),
+    createRun: (run) => delegate.createRun(run),
+    claimNextRun: async (workflowNames, staleBefore) => {
+      claimCalls++
+      if (claimCalls === 2) {
+        secondClaimStarted.resolve()
+        await releaseSecondClaim
+      }
+      return delegate.claimNextRun(workflowNames, staleBefore)
+    },
+    heartbeatRun: (runId, leaseId) => delegate.heartbeatRun(runId, leaseId),
+    getRun: (runId) => delegate.getRun(runId),
+    getStepResults: (runId) => delegate.getStepResults(runId),
+    saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),
+    updateRunStatus: (runId, status) => delegate.updateRunStatus(runId, status),
+    updateClaimedRunStatus: (runId, leaseId, status) =>
+      delegate.updateClaimedRunStatus(runId, leaseId, status),
+    close: () => delegate.close(),
+  }
 }
 
 describe('async hooks', () => {
@@ -98,6 +156,203 @@ describe('async hooks', () => {
       output: { result: 42 },
     })
   })
+
+  it('awaits async start and failure hooks in lifecycle order', async () => {
+    const order: string[] = []
+    const wf = createWorkflow({ name: 'hook-order', input: z.object({}) })
+      .step('broken', async () => {
+        order.push('handler')
+        throw new Error('boom')
+      })
+
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onRunStart: async () => {
+          await delay(1)
+          order.push('run-start')
+        },
+        onStepStart: async () => {
+          await delay(1)
+          order.push('step-start')
+        },
+        onRunFailed: async () => {
+          await delay(1)
+          order.push('run-failed')
+        },
+      },
+    })
+
+    await engine.enqueue('hook-order', {})
+    await engine.tick()
+
+    expect(order).toEqual(['run-start', 'step-start', 'handler', 'run-failed'])
+  })
+
+  it('cancelling a run interrupts a pending async hook', async () => {
+    const hookStarted = deferred()
+    const wf = createWorkflow({ name: 'cancel-hook', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onRunStart: () => {
+          hookStarted.resolve()
+          return new Promise<void>(() => {})
+        },
+      },
+    })
+
+    const run = await engine.enqueue('cancel-hook', {})
+    const tickPromise = engine.tick()
+    await hookStarted.promise
+
+    expect(await engine.cancel(run.id)).toBe(true)
+    await settlesWithin(tickPromise)
+
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('cancelled')
+  })
+
+  it('stop() interrupts a pending async hook and waits for the tick to settle', async () => {
+    const hookStarted = deferred()
+    const wf = createWorkflow({ name: 'stop-hook', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onRunStart: () => {
+          hookStarted.resolve()
+          return new Promise<void>(() => {})
+        },
+      },
+    })
+
+    const run = await engine.enqueue('stop-hook', {})
+    const tickPromise = engine.tick()
+    await hookStarted.promise
+
+    await settlesWithin(engine.stop())
+    await settlesWithin(tickPromise)
+
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('running')
+  })
+
+  it('stop() interrupts a failure hook after a heartbeat error aborted execution', async () => {
+    const delegate = new MemoryStorage()
+    await delegate.initialize()
+    let heartbeatCalls = 0
+    const flakyStorage: StorageAdapter = {
+      initialize: () => delegate.initialize(),
+      createRun: (run) => delegate.createRun(run),
+      claimNextRun: (workflowNames, staleBefore) =>
+        delegate.claimNextRun(workflowNames, staleBefore),
+      heartbeatRun: async (runId, leaseId) => {
+        heartbeatCalls++
+        if (heartbeatCalls === 1) throw new Error('heartbeat failed')
+        return delegate.heartbeatRun(runId, leaseId)
+      },
+      getRun: (runId) => delegate.getRun(runId),
+      getStepResults: (runId) => delegate.getStepResults(runId),
+      saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),
+      updateRunStatus: (runId, status) => delegate.updateRunStatus(runId, status),
+      updateClaimedRunStatus: (runId, leaseId, status) =>
+        delegate.updateClaimedRunStatus(runId, leaseId, status),
+      close: () => delegate.close(),
+    }
+    const failureHookStarted = deferred()
+    const wf = createWorkflow({ name: 'heartbeat-hook', input: z.object({}) })
+      .step('slow', async ({ signal }) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 1000)
+          signal.addEventListener('abort', () => {
+            clearTimeout(timer)
+            reject(signal.reason)
+          }, { once: true })
+        })
+        return { ok: true }
+      })
+
+    const engine = createEngine({
+      storage: flakyStorage,
+      workflows: [wf],
+      runLeaseDurationMs: 30,
+      heartbeatIntervalMs: 5,
+      hooks: {
+        onRunFailed: () => {
+          failureHookStarted.resolve()
+          return new Promise<void>(() => {})
+        },
+      },
+    })
+
+    await engine.enqueue('heartbeat-hook', {})
+    const tickPromise = engine.tick()
+    await failureHookStarted.promise
+
+    await settlesWithin(engine.stop())
+    await settlesWithin(tickPromise)
+  })
+})
+
+describe('engine control boundaries', () => {
+  it('does not execute a run cancelled after claim but before active registration', async () => {
+    const delegate = new MemoryStorage()
+    await delegate.initialize()
+    const secondClaimStarted = deferred()
+    const releaseSecondClaim = deferred()
+    const storage = delaySecondClaim(
+      delegate,
+      secondClaimStarted,
+      releaseSecondClaim.promise,
+    )
+    const handler = vi.fn(async () => ({ ok: true }))
+    const wf = createWorkflow({ name: 'cancel-before-register', input: z.object({}) })
+      .step('a', handler)
+    const engine = createEngine({ storage, workflows: [wf], concurrency: 2 })
+
+    const run = await engine.enqueue('cancel-before-register', {})
+    const tickPromise = engine.tick()
+    await secondClaimStarted.promise
+
+    expect(await engine.cancel(run.id)).toBe(true)
+    releaseSecondClaim.resolve()
+    await tickPromise
+
+    expect(handler).not.toHaveBeenCalled()
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('cancelled')
+  })
+
+  it('does not start claimed runs when stop() lands before active registration', async () => {
+    const delegate = new MemoryStorage()
+    await delegate.initialize()
+    const secondClaimStarted = deferred()
+    const releaseSecondClaim = deferred()
+    const storage = delaySecondClaim(
+      delegate,
+      secondClaimStarted,
+      releaseSecondClaim.promise,
+    )
+    const handler = vi.fn(async () => ({ ok: true }))
+    const wf = createWorkflow({ name: 'stop-before-register', input: z.object({}) })
+      .step('a', handler)
+    const engine = createEngine({ storage, workflows: [wf], concurrency: 2 })
+
+    const run = await engine.enqueue('stop-before-register', {})
+    const tickPromise = engine.tick()
+    await secondClaimStarted.promise
+
+    const stopPromise = engine.stop()
+    releaseSecondClaim.resolve()
+    await Promise.all([stopPromise, tickPromise])
+
+    expect(handler).not.toHaveBeenCalled()
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('running')
+  })
 })
 
 describe('engine.stream()', () => {
@@ -106,6 +361,96 @@ describe('engine.stream()', () => {
   beforeEach(async () => {
     storage = new MemoryStorage()
     await storage.initialize()
+  })
+
+  it.each([
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['NaN', Number.NaN],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+  ])('rejects an invalid %s buffer size', (_label, bufferSize) => {
+    const wf = createWorkflow({ name: 'invalid-buffer', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    expect(() => engine.stream({ bufferSize })).toThrow(
+      'Stream bufferSize must be a non-negative integer or Infinity',
+    )
+  })
+
+  it('accepts zero-capacity and unbounded streams', async () => {
+    const wf = createWorkflow({ name: 'valid-buffer', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const rendezvous = engine.stream({ bufferSize: 0 })
+    const unbounded = engine.stream({ bufferSize: Number.POSITIVE_INFINITY })
+
+    await rendezvous.return?.()
+    await unbounded.return?.()
+  })
+
+  it('supports zero-capacity rendezvous without starting work before each pull', async () => {
+    const handler = vi.fn(async () => ({ ok: true }))
+    const wf = createWorkflow({ name: 'rendezvous', input: z.object({}) })
+      .step('a', handler)
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream({ bufferSize: 0 })
+
+    await engine.enqueue('rendezvous', {})
+    const tickPromise = engine.tick()
+    await delay(10)
+    expect(handler).not.toHaveBeenCalled()
+
+    expect((await stream.next()).value.type).toBe('runStart')
+    await delay(10)
+    expect(handler).not.toHaveBeenCalled()
+
+    expect((await stream.next()).value.type).toBe('stepStart')
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    const remaining: string[] = []
+    for await (const event of stream) {
+      remaining.push(event.type)
+      if (event.type === 'runComplete') break
+    }
+
+    await tickPromise
+    expect(remaining).toEqual(['stepComplete', 'runComplete'])
+  })
+
+  it('never buffers more than the configured capacity', async () => {
+    const stepStartHook = deferred()
+    const wf = createWorkflow({ name: 'strict-capacity', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onStepStart: () => {
+          stepStartHook.resolve()
+        },
+      },
+    })
+    const stream = engine.stream({ bufferSize: 1 })
+
+    await engine.enqueue('strict-capacity', {})
+    const tickPromise = engine.tick()
+    await stepStartHook.promise
+    await delay(0)
+
+    await engine.stop()
+    await tickPromise
+
+    const buffered: string[] = []
+    while (true) {
+      const result = await stream.next()
+      if (result.done) break
+      buffered.push(result.value.type)
+    }
+
+    expect(buffered).toEqual(['runStart'])
   })
 
   it('yields lifecycle events in order for a single run', async () => {
@@ -178,6 +523,43 @@ describe('engine.stream()', () => {
     expect(completions).toEqual(new Set(['wf-a', 'wf-b']))
   })
 
+  it('preserves per-run ordering with concurrent producers and a bounded buffer', async () => {
+    const wf = createWorkflow({ name: 'concurrent-stream', input: z.object({ value: z.number() }) })
+      .step('a', async ({ input }) => ({ value: input.value }))
+    const engine = createEngine({ storage, workflows: [wf], concurrency: 3 })
+    const stream = engine.stream({ bufferSize: 1 })
+    const runs = await Promise.all([
+      engine.enqueue('concurrent-stream', { value: 1 }),
+      engine.enqueue('concurrent-stream', { value: 2 }),
+      engine.enqueue('concurrent-stream', { value: 3 }),
+    ])
+
+    const eventsByRun = new Map<string, string[]>()
+    const consumer = (async () => {
+      let completions = 0
+      for await (const event of stream) {
+        const events = eventsByRun.get(event.runId) ?? []
+        events.push(event.type)
+        eventsByRun.set(event.runId, events)
+        if (event.type === 'runComplete') {
+          completions++
+          if (completions === runs.length) break
+        }
+      }
+    })()
+
+    await Promise.all([engine.tick(), consumer])
+
+    for (const run of runs) {
+      expect(eventsByRun.get(run.id)).toEqual([
+        'runStart',
+        'stepStart',
+        'stepComplete',
+        'runComplete',
+      ])
+    }
+  })
+
   it('applies backpressure: the engine pauses until the consumer pulls', async () => {
     const wf = createWorkflow({ name: 'backpressure', input: z.object({}) })
       .step('a', async () => ({ x: 1 }))
@@ -215,6 +597,85 @@ describe('engine.stream()', () => {
     expect(info?.run.status).toBe('completed')
   })
 
+  it('cancelling a backpressured run releases tick() without stopping the engine', async () => {
+    const wf = createWorkflow({ name: 'cancel-backpressure', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream({ bufferSize: 1 })
+
+    const run = await engine.enqueue('cancel-backpressure', {})
+    const tickPromise = engine.tick()
+    await vi.waitFor(async () => {
+      expect((await engine.getRunStatus(run.id))?.run.status).toBe('running')
+    })
+
+    expect(await engine.cancel(run.id)).toBe(true)
+    await settlesWithin(tickPromise)
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('cancelled')
+
+    await stream.return?.()
+    const nextRun = await engine.enqueue('cancel-backpressure', {})
+    await settlesWithin(engine.tick())
+    expect((await engine.getRunStatus(nextRun.id))?.run.status).toBe('completed')
+  })
+
+  it('lease loss releases a producer paused on backpressure', async () => {
+    const delegate = new MemoryStorage()
+    await delegate.initialize()
+    const leaseLosingStorage: StorageAdapter = {
+      initialize: () => delegate.initialize(),
+      createRun: (run) => delegate.createRun(run),
+      claimNextRun: (workflowNames, staleBefore) =>
+        delegate.claimNextRun(workflowNames, staleBefore),
+      heartbeatRun: async () => false,
+      getRun: (runId) => delegate.getRun(runId),
+      getStepResults: (runId) => delegate.getStepResults(runId),
+      saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),
+      updateRunStatus: (runId, status) => delegate.updateRunStatus(runId, status),
+      updateClaimedRunStatus: (runId, leaseId, status) =>
+        delegate.updateClaimedRunStatus(runId, leaseId, status),
+      close: () => delegate.close(),
+    }
+    const wf = createWorkflow({ name: 'lease-backpressure', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({
+      storage: leaseLosingStorage,
+      workflows: [wf],
+      runLeaseDurationMs: 30,
+      heartbeatIntervalMs: 5,
+    })
+    const stream = engine.stream({ bufferSize: 1 })
+
+    const run = await engine.enqueue('lease-backpressure', {})
+    await settlesWithin(engine.tick())
+
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('running')
+    await stream.return?.()
+  })
+
+  it('lets an independent stream continue after a backpressured stream is disposed', async () => {
+    const wf = createWorkflow({ name: 'independent-streams', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const blocked = engine.stream({ bufferSize: 0 })
+    const observing = engine.stream()
+
+    await engine.enqueue('independent-streams', {})
+    const tickPromise = engine.tick()
+
+    expect((await observing.next()).value.type).toBe('runStart')
+    await blocked.return?.()
+
+    const observed: string[] = ['runStart']
+    for await (const event of observing) {
+      observed.push(event.type)
+      if (event.type === 'runComplete') break
+    }
+
+    await tickPromise
+    expect(observed).toEqual(['runStart', 'stepStart', 'stepComplete', 'runComplete'])
+  })
+
   it('unsubscribes when the consumer breaks out of the loop', async () => {
     const wf = createWorkflow({ name: 'unsub', input: z.object({}) })
       .step('a', async () => ({ x: 1 }))
@@ -233,12 +694,7 @@ describe('engine.stream()', () => {
 
     // A dead stream must not hold backpressure on future runs.
     const run = await engine.enqueue('unsub', {})
-    await Promise.race([
-      engine.tick(),
-      delay(500).then(() => {
-        throw new Error('tick() hung — disposed stream still applied backpressure')
-      }),
-    ])
+    await settlesWithin(engine.tick())
 
     const info = await engine.getRunStatus(run.id)
     expect(info?.run.status).toBe('completed')
@@ -269,6 +725,194 @@ describe('engine.stream()', () => {
 
     expect(hookEvents).toEqual(['hook'])
     expect(streamSawComplete).toBe(true)
+  })
+
+  it('isolates hook output mutations from workflow state and stream events', async () => {
+    let downstreamValue: number | undefined
+    const wf = createWorkflow({ name: 'hook-isolation', input: z.object({}) })
+      .step('a', async () => ({ nested: { value: 1 } }))
+      .step('b', async ({ prev }) => {
+        downstreamValue = prev.nested.value
+        return { observed: downstreamValue }
+      })
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onStepComplete: (event) => {
+          if (event.stepName === 'a') {
+            const output = event.output as { nested: { value: number } }
+            output.nested.value = 999
+          }
+        },
+      },
+    })
+    const stream = engine.stream()
+
+    await engine.enqueue('hook-isolation', {})
+    await engine.tick()
+
+    let streamedValue: number | undefined
+    for await (const event of stream) {
+      if (event.type === 'stepComplete' && event.stepName === 'a') {
+        streamedValue = (event.output as { nested: { value: number } }).nested.value
+      }
+      if (event.type === 'runComplete') break
+    }
+
+    expect(downstreamValue).toBe(1)
+    expect(streamedValue).toBe(1)
+  })
+
+  it('gives each stream an isolated output snapshot', async () => {
+    const wf = createWorkflow({ name: 'stream-isolation', input: z.object({}) })
+      .step('a', async () => ({ nested: { value: 1 } }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const firstStream = engine.stream()
+    const secondStream = engine.stream()
+
+    await engine.enqueue('stream-isolation', {})
+    await engine.tick()
+
+    for await (const event of firstStream) {
+      if (event.type === 'stepComplete') {
+        const output = event.output as { nested: { value: number } }
+        output.nested.value = 999
+        break
+      }
+    }
+
+    let secondValue: number | undefined
+    for await (const event of secondStream) {
+      if (event.type === 'stepComplete') {
+        secondValue = (event.output as { nested: { value: number } }).nested.value
+        break
+      }
+    }
+
+    expect(secondValue).toBe(1)
+  })
+
+  it('isolates hook error mutations from failure handlers and streams', async () => {
+    let failureHandlerMessage: string | undefined
+    const wf = createWorkflow({ name: 'error-isolation', input: z.object({}) })
+      .step('broken', async () => {
+        throw new Error('original failure')
+      })
+      .onFailure(async ({ error }) => {
+        failureHandlerMessage = error.message
+      })
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onRunFailed: (event) => {
+          event.error.message = 'mutated by hook'
+        },
+      },
+    })
+    const stream = engine.stream()
+
+    await engine.enqueue('error-isolation', {})
+    await engine.tick()
+
+    let streamMessage: string | undefined
+    for await (const event of stream) {
+      if (event.type === 'runFailed') {
+        streamMessage = event.error.message
+        break
+      }
+    }
+
+    expect(failureHandlerMessage).toBe('original failure')
+    expect(streamMessage).toBe('original failure')
+  })
+
+  it('emits runFailed with the original error and never emits runComplete', async () => {
+    const failure = new Error('stream failure')
+    const wf = createWorkflow({ name: 'stream-failure', input: z.object({}) })
+      .step('broken', async () => {
+        throw failure
+      })
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    const run = await engine.enqueue('stream-failure', {})
+    await engine.tick()
+
+    const types: string[] = []
+    let observedError: Error | undefined
+    for await (const event of stream) {
+      types.push(event.type)
+      if (event.type === 'runFailed') {
+        observedError = event.error
+        break
+      }
+    }
+
+    expect(types).toEqual(['runStart', 'stepStart', 'runFailed'])
+    expect(observedError).toBeInstanceOf(Error)
+    expect(observedError).not.toBe(failure)
+    expect(observedError?.message).toBe(failure.message)
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('failed')
+  })
+
+  it('emits stepComplete and runComplete with the early completion output', async () => {
+    const neverRuns = vi.fn(async () => ({ unexpected: true }))
+    const wf = createWorkflow({ name: 'stream-early-complete', input: z.object({}) })
+      .step('check', async ({ complete }) => complete({ done: true }))
+      .step('after', neverRuns)
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    await engine.enqueue('stream-early-complete', {})
+    await engine.tick()
+
+    const events: EngineEvent[] = []
+    for await (const event of stream) {
+      events.push(event)
+      if (event.type === 'runComplete') break
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      'runStart',
+      'stepStart',
+      'stepComplete',
+      'runComplete',
+    ])
+    expect(events.find((event) => event.type === 'stepComplete')?.output).toEqual({ done: true })
+    expect(events.find((event) => event.type === 'runComplete')?.output).toEqual({ done: true })
+    expect(neverRuns).not.toHaveBeenCalled()
+  })
+
+  it('emits all parallel starts before completions and returns the merged output', async () => {
+    const wf = createWorkflow({ name: 'stream-parallel', input: z.object({}) })
+      .parallel({
+        a: async () => ({ value: 'a' }),
+        b: async () => ({ value: 'b' }),
+      })
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    await engine.enqueue('stream-parallel', {})
+    await engine.tick()
+
+    const events: EngineEvent[] = []
+    for await (const event of stream) {
+      events.push(event)
+      if (event.type === 'runComplete') break
+    }
+
+    const eventTypes = events.map((event) => event.type)
+    const firstCompletion = eventTypes.indexOf('stepComplete')
+    const lastStart = eventTypes.lastIndexOf('stepStart')
+    expect(lastStart).toBeLessThan(firstCompletion)
+    expect(events.filter((event) => event.type === 'stepStart')).toHaveLength(2)
+    expect(events.filter((event) => event.type === 'stepComplete')).toHaveLength(2)
+    expect(events.find((event) => event.type === 'runComplete')?.output).toEqual({
+      a: { value: 'a' },
+      b: { value: 'b' },
+    })
   })
 
   it('leaves a run reclaimable (not failed) when stopped while paused on backpressure', async () => {
@@ -329,12 +973,7 @@ describe('engine.stream()', () => {
 
     await engine.stop()
     // The consumer loop must terminate once the engine stops.
-    await Promise.race([
-      consumer,
-      delay(500).then(() => {
-        throw new Error('stream did not close on engine stop')
-      }),
-    ])
+    await settlesWithin(consumer)
   })
 
   it('resolves a pending next() as done when the stream is disposed', async () => {
@@ -349,6 +988,90 @@ describe('engine.stream()', () => {
     await stream.return?.()
 
     await expect(pending).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('resolves concurrent next() calls in event order', async () => {
+    const wf = createWorkflow({ name: 'concurrent-pulls', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    const first = stream.next()
+    const second = stream.next()
+    const third = stream.next()
+    await engine.enqueue('concurrent-pulls', {})
+    const tickPromise = engine.tick()
+
+    expect((await first).value.type).toBe('runStart')
+    expect((await second).value.type).toBe('stepStart')
+    expect((await third).value.type).toBe('stepComplete')
+
+    await stream.return?.()
+    await tickPromise
+  })
+
+  it('return() is terminal and discards buffered events', async () => {
+    const wf = createWorkflow({ name: 'terminal-return', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    await engine.enqueue('terminal-return', {})
+    await engine.tick()
+    await stream.return?.()
+
+    await expect(stream.next()).resolves.toEqual({ value: undefined, done: true })
+    await expect(stream.next()).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('throw() is terminal, preserves the thrown value, and unblocks producers', async () => {
+    const wf = createWorkflow({ name: 'terminal-throw', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream({ bufferSize: 1 })
+    const thrown = { reason: 'consumer failed' }
+
+    await engine.enqueue('terminal-throw', {})
+    const tickPromise = engine.tick()
+    await delay(10)
+
+    await expect(stream.throw?.(thrown)).rejects.toBe(thrown)
+    await settlesWithin(tickPromise)
+    await expect(stream.next()).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('disposal is idempotent', async () => {
+    const wf = createWorkflow({ name: 'idempotent-dispose', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    await stream.return?.()
+    await stream.return?.()
+    await stream[Symbol.asyncDispose]()
+
+    await expect(stream.next()).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('allows a new stream after stop() closed previous subscriptions', async () => {
+    const wf = createWorkflow({ name: 'stream-after-stop', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+    const engine = createEngine({ storage, workflows: [wf] })
+    const oldStream = engine.stream()
+
+    await engine.stop()
+    await expect(oldStream.next()).resolves.toEqual({ value: undefined, done: true })
+
+    const newStream = engine.stream()
+    await engine.enqueue('stream-after-stop', {})
+    await engine.tick()
+
+    const types: string[] = []
+    for await (const event of newStream) {
+      types.push(event.type)
+      if (event.type === 'runComplete') break
+    }
+    expect(types).toEqual(['runStart', 'stepStart', 'stepComplete', 'runComplete'])
   })
 
   it('supports await using for disposal', async () => {

--- a/src/core/__tests__/stream.test.ts
+++ b/src/core/__tests__/stream.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
+import { createWorkflow } from '../workflow'
+import { createEngine } from '../engine'
+import type { EngineEvent } from '../engine'
+import { MemoryStorage } from '../../storage/memory'
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('async hooks', () => {
+  let storage: MemoryStorage
+
+  beforeEach(async () => {
+    storage = new MemoryStorage()
+    await storage.initialize()
+  })
+
+  it('awaits an async hook before running the next step', async () => {
+    const order: string[] = []
+
+    const wf = createWorkflow({ name: 'async-hook', input: z.object({}) })
+      .step('a', async () => {
+        order.push('a-run')
+        return { x: 1 }
+      })
+      .step('b', async () => {
+        order.push('b-run')
+        return { y: 2 }
+      })
+
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onStepComplete: async (event) => {
+          await delay(5)
+          order.push(`hook-${event.stepName}`)
+        },
+      },
+    })
+
+    await engine.enqueue('async-hook', {})
+    await engine.tick()
+
+    // The async onStepComplete for 'a' must settle before 'b' begins.
+    expect(order).toEqual(['a-run', 'hook-a', 'b-run', 'hook-b'])
+  })
+
+  it('a rejecting async hook does not fail the run', async () => {
+    const wf = createWorkflow({ name: 'reject-hook', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onStepComplete: async () => {
+          await delay(1)
+          throw new Error('async hook boom')
+        },
+      },
+    })
+
+    const run = await engine.enqueue('reject-hook', {})
+    await expect(engine.tick()).resolves.toBeUndefined()
+
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('completed')
+  })
+
+  it('awaits async onRunComplete with the final run output', async () => {
+    let captured: EngineEvent | undefined
+
+    const wf = createWorkflow({ name: 'final-output', input: z.object({}) })
+      .step('a', async () => ({ step: 'a' }))
+      .step('b', async () => ({ result: 42 }))
+
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: {
+        onRunComplete: async (event) => {
+          await delay(1)
+          captured = event
+        },
+      },
+    })
+
+    await engine.enqueue('final-output', {})
+    await engine.tick()
+
+    expect(captured).toEqual({
+      type: 'runComplete',
+      runId: expect.any(String),
+      workflow: 'final-output',
+      output: { result: 42 },
+    })
+  })
+})
+
+describe('engine.stream()', () => {
+  let storage: MemoryStorage
+
+  beforeEach(async () => {
+    storage = new MemoryStorage()
+    await storage.initialize()
+  })
+
+  it('yields lifecycle events in order for a single run', async () => {
+    const wf = createWorkflow({ name: 'stream-order', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+      .step('b', async () => ({ y: 2 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    await engine.enqueue('stream-order', {})
+    await engine.tick()
+
+    const types: string[] = []
+    for await (const event of stream) {
+      types.push(event.type)
+      if (event.type === 'runComplete') break
+    }
+
+    expect(types).toEqual([
+      'runStart',
+      'stepStart',
+      'stepComplete',
+      'stepStart',
+      'stepComplete',
+      'runComplete',
+    ])
+  })
+
+  it('delivers the final output on runComplete', async () => {
+    const wf = createWorkflow({ name: 'stream-output', input: z.object({}) })
+      .step('a', async () => ({ done: true, value: 7 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream()
+
+    await engine.enqueue('stream-output', {})
+    await engine.tick()
+
+    let output: unknown
+    for await (const event of stream) {
+      if (event.type === 'runComplete') {
+        output = event.output
+        break
+      }
+    }
+
+    expect(output).toEqual({ done: true, value: 7 })
+  })
+
+  it('tags every event with its workflow name across multiple workflows', async () => {
+    const wfA = createWorkflow({ name: 'wf-a', input: z.object({}) }).step('s', async () => ({ a: 1 }))
+    const wfB = createWorkflow({ name: 'wf-b', input: z.object({}) }).step('s', async () => ({ b: 1 }))
+
+    const engine = createEngine({ storage, workflows: [wfA, wfB], concurrency: 2 })
+    const stream = engine.stream()
+
+    await engine.enqueue('wf-a', {})
+    await engine.enqueue('wf-b', {})
+    await engine.tick()
+
+    const completions = new Set<string>()
+    for await (const event of stream) {
+      if (event.type === 'runComplete') {
+        completions.add(event.workflow)
+        if (completions.size === 2) break
+      }
+    }
+
+    expect(completions).toEqual(new Set(['wf-a', 'wf-b']))
+  })
+
+  it('applies backpressure: the engine pauses until the consumer pulls', async () => {
+    const wf = createWorkflow({ name: 'backpressure', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+      .step('b', async () => ({ y: 2 }))
+      .step('c', async () => ({ z: 3 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream({ bufferSize: 1 })
+
+    const run = await engine.enqueue('backpressure', {})
+
+    let tickSettled = false
+    const tickPromise = engine.tick().then(() => {
+      tickSettled = true
+    })
+
+    // With a 1-event buffer and no consumer, the engine blocks early.
+    await delay(30)
+    expect(tickSettled).toBe(false)
+    const midInfo = await engine.getRunStatus(run.id)
+    expect(midInfo?.run.status).not.toBe('completed')
+
+    // Draining the stream unblocks the producer and lets the run finish.
+    const types: string[] = []
+    for await (const event of stream) {
+      types.push(event.type)
+      if (event.type === 'runComplete') break
+    }
+
+    await tickPromise
+    expect(tickSettled).toBe(true)
+    expect(types.at(-1)).toBe('runComplete')
+
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('completed')
+  })
+
+  it('unsubscribes when the consumer breaks out of the loop', async () => {
+    const wf = createWorkflow({ name: 'unsub', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    const stream = engine.stream({ bufferSize: 1 })
+
+    // Consume one event then break — `for await` calls return(), disposing the stream.
+    await engine.enqueue('unsub', {})
+    const firstTick = engine.tick()
+    for await (const event of stream) {
+      void event
+      break
+    }
+    await firstTick
+
+    // A dead stream must not hold backpressure on future runs.
+    const run = await engine.enqueue('unsub', {})
+    await Promise.race([
+      engine.tick(),
+      delay(500).then(() => {
+        throw new Error('tick() hung — disposed stream still applied backpressure')
+      }),
+    ])
+
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('completed')
+  })
+
+  it('hooks and streams both observe the same run', async () => {
+    const wf = createWorkflow({ name: 'both', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+
+    const hookEvents: string[] = []
+    const engine = createEngine({
+      storage,
+      workflows: [wf],
+      hooks: { onRunComplete: () => hookEvents.push('hook') },
+    })
+    const stream = engine.stream()
+
+    await engine.enqueue('both', {})
+    await engine.tick()
+
+    let streamSawComplete = false
+    for await (const event of stream) {
+      if (event.type === 'runComplete') {
+        streamSawComplete = true
+        break
+      }
+    }
+
+    expect(hookEvents).toEqual(['hook'])
+    expect(streamSawComplete).toBe(true)
+  })
+
+  it('ends open streams when the engine stops', async () => {
+    const wf = createWorkflow({ name: 'stop-stream', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+    await engine.start(10_000)
+    const stream = engine.stream()
+
+    const drained: EngineEvent[] = []
+    const consumer = (async () => {
+      for await (const event of stream) {
+        drained.push(event)
+      }
+    })()
+
+    await engine.stop()
+    // The consumer loop must terminate once the engine stops.
+    await Promise.race([
+      consumer,
+      delay(500).then(() => {
+        throw new Error('stream did not close on engine stop')
+      }),
+    ])
+  })
+
+  it('supports await using for disposal', async () => {
+    const wf = createWorkflow({ name: 'dispose', input: z.object({}) })
+      .step('a', async () => ({ x: 1 }))
+
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    let observed: string | undefined
+    {
+      await using stream = engine.stream()
+      await engine.enqueue('dispose', {})
+      await engine.tick()
+      for await (const event of stream) {
+        if (event.type === 'runComplete') {
+          observed = event.workflow
+          break
+        }
+      }
+    }
+
+    expect(observed).toBe('dispose')
+
+    // After disposal, a new run completes without the old stream blocking it.
+    const run = await engine.enqueue('dispose', {})
+    await engine.tick()
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('completed')
+  })
+})

--- a/src/core/__tests__/type-safety.test.ts
+++ b/src/core/__tests__/type-safety.test.ts
@@ -3,7 +3,16 @@ import { z } from 'zod'
 import { createWorkflow, createEngine } from '../../index'
 import { testEngine } from '../../test/index'
 import { MemoryStorage } from '../../storage/memory'
-import type { Workflow, FailureContext, StepContext } from '../../index'
+import type {
+  EngineEvent,
+  EngineEventOf,
+  EngineHooks,
+  FailureContext,
+  PersistedValue,
+  ResultStream,
+  StepContext,
+  Workflow,
+} from '../../index'
 
 describe('type safety', () => {
   const orderWorkflow = createWorkflow({
@@ -71,6 +80,50 @@ describe('type safety', () => {
 
     // Only registered workflow names are accepted as first argument
     expectTypeOf(engine.enqueue).parameter(0).toEqualTypeOf<'order' | 'math'>()
+  })
+
+  it('engine.stream returns a discriminated async event stream', () => {
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [orderWorkflow] })
+    const stream = engine.stream({ bufferSize: 1 })
+
+    expectTypeOf(stream).toEqualTypeOf<ResultStream>()
+    expectTypeOf<EngineEventOf<'runComplete'>>().toEqualTypeOf<{
+      readonly type: 'runComplete'
+      readonly runId: string
+      readonly workflow: string
+      readonly output: PersistedValue
+    }>()
+
+    const narrow = (event: EngineEvent) => {
+      if (event.type === 'stepComplete') {
+        expectTypeOf(event.output).toEqualTypeOf<PersistedValue>()
+        expectTypeOf(event.attempts).toEqualTypeOf<number>()
+        expectTypeOf(event.stepName).toEqualTypeOf<string>()
+      } else if (event.type === 'runFailed') {
+        expectTypeOf(event.error).toEqualTypeOf<Error>()
+        expectTypeOf(event.stepName).toEqualTypeOf<string>()
+      } else if (event.type === 'runComplete') {
+        expectTypeOf(event.output).toEqualTypeOf<PersistedValue>()
+      }
+    }
+    void narrow
+  })
+
+  it('lifecycle hooks accept async callbacks with narrowed event types', () => {
+    const hooks: EngineHooks = {
+      onRunStart: async (event) => {
+        expectTypeOf(event).toEqualTypeOf<EngineEventOf<'runStart'>>()
+      },
+      onStepComplete: async (event) => {
+        expectTypeOf(event).toEqualTypeOf<EngineEventOf<'stepComplete'>>()
+      },
+      onRunFailed: async (event) => {
+        expectTypeOf(event).toEqualTypeOf<EngineEventOf<'runFailed'>>()
+      },
+    }
+
+    expect(hooks).toBeDefined()
   })
 
   it('onFailure handler receives typed input', () => {

--- a/src/core/async-iterator.ts
+++ b/src/core/async-iterator.ts
@@ -1,0 +1,179 @@
+export interface AbortableSubscriber<T> {
+  push(value: T, signal: AbortSignal): Promise<void>
+  close(): void
+}
+
+export interface AsyncDisposableIterator<T> extends AsyncIterableIterator<T> {
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+interface PendingPush<T> {
+  value: T
+  resolve: () => void
+  reject: (error: Error) => void
+  signal: AbortSignal
+  onAbort: () => void
+  settled: boolean
+}
+
+export function createBoundedAsyncIterator<T>(
+  capacity: number,
+  onDispose: () => void,
+): {
+  iterator: AsyncDisposableIterator<T>
+  subscriber: AbortableSubscriber<T>
+} {
+  const buffer: T[] = []
+  const pullWaiters: Array<(result: IteratorResult<T>) => void> = []
+  const pushWaiters: Array<PendingPush<T>> = []
+  let closed = false
+  let disposed = false
+
+  const settlePush = (
+    waiter: PendingPush<T>,
+    outcome: { kind: 'resolve' } | { kind: 'reject'; error: Error },
+  ): void => {
+    if (waiter.settled) return
+    waiter.settled = true
+    waiter.signal.removeEventListener('abort', waiter.onAbort)
+    if (outcome.kind === 'resolve') {
+      waiter.resolve()
+    } else {
+      waiter.reject(outcome.error)
+    }
+  }
+
+  const shiftPushWaiter = (): PendingPush<T> | undefined => {
+    const waiter = pushWaiters.shift()
+    if (waiter) {
+      waiter.settled = true
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
+    }
+    return waiter
+  }
+
+  const fillAvailableCapacity = (): void => {
+    while (!closed && buffer.length < capacity && pushWaiters.length > 0) {
+      const waiter = shiftPushWaiter()
+      if (!waiter) break
+      buffer.push(waiter.value)
+      waiter.resolve()
+    }
+  }
+
+  const releasePushWaiters = (): void => {
+    for (const waiter of pushWaiters.splice(0)) {
+      settlePush(waiter, { kind: 'resolve' })
+    }
+  }
+
+  const releasePullWaiters = (): void => {
+    for (const waiter of pullWaiters.splice(0)) {
+      waiter({ value: undefined, done: true })
+    }
+  }
+
+  const subscriber: AbortableSubscriber<T> = {
+    push(value, signal) {
+      if (closed) return Promise.resolve()
+      if (signal.aborted) return Promise.reject(toError(signal.reason))
+
+      const pullWaiter = pullWaiters.shift()
+      if (pullWaiter) {
+        pullWaiter({ value, done: false })
+        return Promise.resolve()
+      }
+
+      if (pushWaiters.length === 0 && buffer.length < capacity) {
+        buffer.push(value)
+        return Promise.resolve()
+      }
+
+      return new Promise<void>((resolve, reject) => {
+        const pending: PendingPush<T> = {
+          value,
+          resolve,
+          reject,
+          signal,
+          settled: false,
+          onAbort: () => {
+            const index = pushWaiters.indexOf(pending)
+            if (index !== -1) {
+              pushWaiters.splice(index, 1)
+            }
+            settlePush(pending, { kind: 'reject', error: toError(signal.reason) })
+          },
+        }
+        pushWaiters.push(pending)
+        signal.addEventListener('abort', pending.onAbort, { once: true })
+
+        if (signal.aborted) {
+          pending.onAbort()
+        }
+      })
+    },
+    close() {
+      if (closed) return
+      closed = true
+      releasePushWaiters()
+      releasePullWaiters()
+    },
+  }
+
+  const dispose = (): void => {
+    if (disposed) return
+    disposed = true
+    closed = true
+    buffer.length = 0
+    releasePushWaiters()
+    releasePullWaiters()
+    onDispose()
+  }
+
+  const iterator: AsyncDisposableIterator<T> = {
+    next(): Promise<IteratorResult<T>> {
+      if (disposed) {
+        return Promise.resolve({ value: undefined, done: true })
+      }
+
+      if (buffer.length > 0) {
+        const value = buffer.shift() as T
+        fillAvailableCapacity()
+        return Promise.resolve({ value, done: false })
+      }
+
+      const pending = shiftPushWaiter()
+      if (pending) {
+        pending.resolve()
+        return Promise.resolve({ value: pending.value, done: false })
+      }
+
+      if (closed) {
+        return Promise.resolve({ value: undefined, done: true })
+      }
+
+      return new Promise<IteratorResult<T>>((resolve) => pullWaiters.push(resolve))
+    },
+    return(): Promise<IteratorResult<T>> {
+      dispose()
+      return Promise.resolve({ value: undefined, done: true })
+    },
+    throw(error?: unknown): Promise<IteratorResult<T>> {
+      dispose()
+      return Promise.reject(error)
+    },
+    [Symbol.asyncIterator]() {
+      return iterator
+    },
+    [Symbol.asyncDispose](): Promise<void> {
+      dispose()
+      return Promise.resolve()
+    },
+  }
+
+  return { iterator, subscriber }
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -354,6 +354,11 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     const dispose = (): void => {
       subscribers.delete(subscriber)
       closed = true
+      // Resolve a pending consumer (a manual next() awaiting an empty buffer) as
+      // done, and unblock any paused producer, so nothing is left hanging.
+      for (const waiter of pullWaiters.splice(0)) {
+        waiter({ value: undefined, done: true })
+      }
       for (const resume of pushWaiters.splice(0)) {
         resume()
       }
@@ -453,6 +458,21 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
             const outcome = await executeStep(run, activeRun, stepDef, prev, frozenSteps)
 
             if (outcome.kind === 'failed') {
+              // A control-flow abort (cancel / engine stop / lease loss) can land
+              // on an await point between steps — including a backpressured stream
+              // emit. When it does, executeStep reports a synthetic failure for a
+              // step that never really ran. That is a side effect of the abort, not
+              // a real failure: leave the run untouched (status stays as-is, so a
+              // stopped or lease-lost run remains reclaimable) instead of marking
+              // it failed. A non-control abort reason (e.g. a heartbeat storage
+              // error) is a genuine failure and still falls through below.
+              if (
+                activeRun.runAbortController.signal.aborted &&
+                activeRun.runAbortController.signal.reason instanceof RunControlError
+              ) {
+                return
+              }
+
               // Persist the failed step result
               const now = Date.now()
               const saved = await storage.saveStepResult({
@@ -768,13 +788,17 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         }),
       )
 
-      // If the run itself was cancelled while branches were running, surface that
-      // before reporting branch failures. Cancellation isn't a branch failure.
-      if (activeRun.runAbortController.signal.aborted) {
-        const currentRun = await storage.getRun(run.id)
-        if (!currentRun || currentRun.status === 'cancelled') {
-          return { kind: 'skipped-cancelled' }
-        }
+      // If the run itself was aborted by a control-flow signal while branches were
+      // running (cancel, engine stop, or lease loss), surface that before reporting
+      // branch failures. A branch that failed because it observed the run-level
+      // abort is a downstream effect, not the cause — reporting it would mark a
+      // stopped/reclaimable run as failed. A non-control abort (e.g. a heartbeat
+      // storage error) is a genuine failure and still falls through below.
+      if (
+        activeRun.runAbortController.signal.aborted &&
+        activeRun.runAbortController.signal.reason instanceof RunControlError
+      ) {
+        return { kind: 'skipped-cancelled' }
       }
 
       // Prefer the branch that actually caused the abort; only fall back to scanning

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -21,15 +21,69 @@ import type {
 } from './types'
 import type { AnyWorkflow, StepDefinition, WorkflowInputMap } from './workflow'
 
-/** Lifecycle hooks fired during workflow execution. */
+/**
+ * A lifecycle event emitted during workflow execution.
+ *
+ * Consumed both by the {@link EngineHooks} callbacks and by {@link Engine.stream}.
+ * Every event carries the owning `workflow` name so a single stream can fan out
+ * across multiple workflows.
+ */
+export type EngineEvent =
+  | { readonly type: 'runStart'; readonly runId: string; readonly workflow: string }
+  | { readonly type: 'stepStart'; readonly runId: string; readonly workflow: string; readonly stepName: string }
+  | {
+      readonly type: 'stepComplete'
+      readonly runId: string
+      readonly workflow: string
+      readonly stepName: string
+      readonly output: PersistedValue
+      readonly attempts: number
+    }
+  | { readonly type: 'runComplete'; readonly runId: string; readonly workflow: string; readonly output: PersistedValue }
+  | { readonly type: 'runFailed'; readonly runId: string; readonly workflow: string; readonly stepName: string; readonly error: Error }
+
+/** Narrow {@link EngineEvent} to a single `type` (or union of types). */
+export type EngineEventOf<T extends EngineEvent['type']> = Extract<EngineEvent, { type: T }>
+
+/**
+ * Lifecycle hooks fired during workflow execution.
+ *
+ * Hooks may be synchronous or `async` — an async hook is awaited before the
+ * engine proceeds, so it can apply backpressure or guarantee ordering. A hook
+ * that throws (or rejects) never affects engine state; the error is swallowed.
+ */
 export interface EngineHooks {
-  onRunStart?: (event: { runId: string; workflow: string }) => void
-  onStepStart?: (event: { runId: string; stepName: string }) => void
-  onStepComplete?: (event: { runId: string; stepName: string; output: PersistedValue; attempts: number }) => void
-  onRunComplete?: (event: { runId: string; workflow: string }) => void
-  onRunFailed?: (event: { runId: string; workflow: string; stepName: string; error: Error }) => void
+  onRunStart?: (event: EngineEventOf<'runStart'>) => void
+  onStepStart?: (event: EngineEventOf<'stepStart'>) => void
+  onStepComplete?: (event: EngineEventOf<'stepComplete'>) => void
+  onRunComplete?: (event: EngineEventOf<'runComplete'>) => void
+  onRunFailed?: (event: EngineEventOf<'runFailed'>) => void
   /** Called when a background operation fails (scheduled enqueue, poll cycle). Without this hook, these errors are silently swallowed. */
   onError?: (error: Error) => void
+}
+
+/** Options for {@link Engine.stream}. */
+export interface StreamOptions {
+  /**
+   * Maximum number of events buffered before the engine pauses (backpressure).
+   * Defaults to `Infinity` — events buffer without bound and the engine never
+   * waits on the consumer. Set a finite value (e.g. `1`) to pace the engine
+   * against a slow consumer; the engine will not start the next unit of work
+   * until the consumer drains the buffer below this size.
+   */
+  bufferSize?: number
+}
+
+/**
+ * A pull-based, backpressure-aware stream of {@link EngineEvent}s.
+ *
+ * Implements `AsyncIterableIterator`, so it works directly with `for await`,
+ * and `AsyncDisposable`, so it works with `await using`. Breaking out of a
+ * `for await` loop (or disposing) unsubscribes from the engine automatically.
+ */
+export interface ResultStream<E extends EngineEvent = EngineEvent>
+  extends AsyncIterableIterator<E> {
+  [Symbol.asyncDispose](): Promise<void>
 }
 
 /** Configuration for {@link createEngine}. */
@@ -74,6 +128,21 @@ export interface Engine<TWorkflowMap extends Record<string, PersistedValue> = Re
   ): string
   /** Cancel a recurring schedule by ID. */
   unschedule(scheduleId: string): boolean
+  /**
+   * Subscribe to a live, pull-based stream of execution events
+   * ({@link EngineEvent}). Use it to consume step/run results as they happen,
+   * with optional backpressure:
+   *
+   * ```ts
+   * for await (const event of engine.stream()) {
+   *   if (event.type === 'runComplete') process(event.output)
+   * }
+   * ```
+   *
+   * Each call returns an independent stream. Breaking out of the loop, or
+   * disposing the stream, unsubscribes automatically.
+   */
+  stream(options?: StreamOptions): ResultStream
   /** Process one batch of pending runs. Useful for tests and CLI tools. */
   tick(): Promise<void>
   /** Initialize storage and start the polling loop. Call once at startup. */
@@ -87,6 +156,14 @@ interface ActiveRunState {
   runAbortController: AbortController
   heartbeatTimer: ReturnType<typeof setInterval> | null
   heartbeatInFlight: boolean
+}
+
+/** A single {@link Engine.stream} consumer. */
+interface StreamSubscriber {
+  /** Deliver an event. Resolves once buffered; when the buffer is full, resolves only after the consumer drains it (backpressure). */
+  push(event: EngineEvent): Promise<void>
+  /** End the stream, unblocking any pending consumer and producer waiters. */
+  close(): void
 }
 
 /**
@@ -132,6 +209,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
   const registry = new Map<string, AnyWorkflow>()
   const schedules = new Map<string, ReturnType<typeof setInterval>>()
   const activeRuns = new Map<string, ActiveRunState>()
+  const subscribers = new Set<StreamSubscriber>()
   let running = false
   let timer: ReturnType<typeof setInterval> | null = null
   let tickInFlight = false
@@ -186,6 +264,136 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     return { run, steps }
   }
 
+  /**
+   * Dispatch a lifecycle event to the user hook and every active stream, then
+   * wait for them all to settle. Awaiting here is what lets an `async` hook or a
+   * backpressured stream pace the engine. Neither a throwing hook nor a stream
+   * may affect engine state, so all errors are contained.
+   */
+  async function emit(event: EngineEvent): Promise<void> {
+    try {
+      switch (event.type) {
+        case 'runStart':
+          await hooks?.onRunStart?.(event)
+          break
+        case 'stepStart':
+          await hooks?.onStepStart?.(event)
+          break
+        case 'stepComplete':
+          await hooks?.onStepComplete?.(event)
+          break
+        case 'runComplete':
+          await hooks?.onRunComplete?.(event)
+          break
+        case 'runFailed':
+          await hooks?.onRunFailed?.(event)
+          break
+      }
+    } catch { /* hooks must not affect engine state */ }
+
+    if (subscribers.size > 0) {
+      const deliveries: Array<Promise<void>> = []
+      for (const subscriber of subscribers) {
+        deliveries.push(subscriber.push(event))
+      }
+      try {
+        await Promise.all(deliveries)
+      } catch { /* stream delivery must not affect engine state */ }
+    }
+  }
+
+  /** Report a background error to `onError`, swallowing any error it raises. */
+  function reportError(error: unknown): void {
+    const err = error instanceof Error ? error : new Error(String(error))
+    void (async () => {
+      try {
+        await hooks?.onError?.(err)
+      } catch { /* onError must not throw */ }
+    })()
+  }
+
+  function createStream(options?: StreamOptions): ResultStream {
+    const capacity = options?.bufferSize ?? Number.POSITIVE_INFINITY
+    const buffer: EngineEvent[] = []
+    const pullWaiters: Array<(result: IteratorResult<EngineEvent>) => void> = []
+    const pushWaiters: Array<() => void> = []
+    let closed = false
+
+    const subscriber: StreamSubscriber = {
+      push(event) {
+        if (closed) return Promise.resolve()
+
+        const waiter = pullWaiters.shift()
+        if (waiter) {
+          waiter({ value: event, done: false })
+          return Promise.resolve()
+        }
+
+        buffer.push(event)
+        if (buffer.length <= capacity) {
+          return Promise.resolve()
+        }
+
+        // Buffer is over capacity — pause the producer until the consumer drains it.
+        return new Promise<void>((resolve) => pushWaiters.push(resolve))
+      },
+      close() {
+        if (closed) return
+        closed = true
+        for (const waiter of pullWaiters.splice(0)) {
+          waiter({ value: undefined, done: true })
+        }
+        for (const resume of pushWaiters.splice(0)) {
+          resume()
+        }
+      },
+    }
+
+    subscribers.add(subscriber)
+
+    const dispose = (): void => {
+      subscribers.delete(subscriber)
+      closed = true
+      for (const resume of pushWaiters.splice(0)) {
+        resume()
+      }
+    }
+
+    const stream: ResultStream = {
+      next(): Promise<IteratorResult<EngineEvent>> {
+        const event = buffer.shift()
+        if (event !== undefined) {
+          const resume = pushWaiters.shift()
+          if (resume) resume()
+          return Promise.resolve({ value: event, done: false })
+        }
+
+        if (closed) {
+          return Promise.resolve({ value: undefined, done: true })
+        }
+
+        return new Promise<IteratorResult<EngineEvent>>((resolve) => pullWaiters.push(resolve))
+      },
+      return(): Promise<IteratorResult<EngineEvent>> {
+        dispose()
+        return Promise.resolve({ value: undefined, done: true })
+      },
+      throw(error?: unknown): Promise<IteratorResult<EngineEvent>> {
+        dispose()
+        return Promise.reject(error instanceof Error ? error : new Error(String(error)))
+      },
+      [Symbol.asyncIterator]() {
+        return stream
+      },
+      [Symbol.asyncDispose](): Promise<void> {
+        dispose()
+        return Promise.resolve()
+      },
+    }
+
+    return stream
+  }
+
   async function executeRun(run: ClaimedRun): Promise<void> {
     const wf = registry.get(run.workflow)
     if (!wf) return
@@ -193,9 +401,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     const activeRun = registerActiveRun(run)
 
     try {
-      try {
-        hooks?.onRunStart?.({ runId: run.id, workflow: run.workflow })
-      } catch { /* hooks must not affect engine state */ }
+      await emit({ type: 'runStart', runId: run.id, workflow: run.workflow })
 
       const existingSteps = await storage.getStepResults(run.id)
       const completedMap = new Map(existingSteps.map((step) => [step.name, step]))
@@ -215,23 +421,21 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           const existing = completedMap.get(stepDef.name)
           if (existing?.status === 'completed-early') {
             // This step called complete() in a previous execution — finish the run
-            try {
-              hooks?.onStepComplete?.({
-                runId: run.id,
-                stepName: stepDef.name,
-                output: existing.output,
-                attempts: existing.attempts,
-              })
-            } catch { /* hooks must not affect engine state */ }
+            await emit({
+              type: 'stepComplete',
+              runId: run.id,
+              workflow: run.workflow,
+              stepName: stepDef.name,
+              output: existing.output,
+              attempts: existing.attempts,
+            })
 
             const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
             if (!completed) {
               throw new LeaseExpiredError(run.id)
             }
 
-            try {
-              hooks?.onRunComplete?.({ runId: run.id, workflow: run.workflow })
-            } catch { /* hooks must not affect engine state */ }
+            await emit({ type: 'runComplete', runId: run.id, workflow: run.workflow, output: existing.output })
 
             return
           }
@@ -244,9 +448,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           const frozenSteps = snapshotSteps(stepsAccumulator)
 
           try {
-            try {
-              hooks?.onStepStart?.({ runId: run.id, stepName: stepDef.name })
-            } catch { /* hooks must not affect engine state */ }
+            await emit({ type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: stepDef.name })
 
             const outcome = await executeStep(run, activeRun, stepDef, prev, frozenSteps)
 
@@ -290,14 +492,14 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               throw new LeaseExpiredError(run.id)
             }
 
-            try {
-              hooks?.onStepComplete?.({
-                runId: run.id,
-                stepName: stepDef.name,
-                output: outcome.output,
-                attempts: outcome.attempts,
-              })
-            } catch { /* hooks must not affect engine state */ }
+            await emit({
+              type: 'stepComplete',
+              runId: run.id,
+              workflow: run.workflow,
+              stepName: stepDef.name,
+              output: outcome.output,
+              attempts: outcome.attempts,
+            })
 
             if (outcome.kind === 'early-complete') {
               const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
@@ -305,9 +507,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
                 throw new LeaseExpiredError(run.id)
               }
 
-              try {
-                hooks?.onRunComplete?.({ runId: run.id, workflow: run.workflow })
-              } catch { /* hooks must not affect engine state */ }
+              await emit({ type: 'runComplete', runId: run.id, workflow: run.workflow, output: outcome.output })
 
               return
             }
@@ -337,9 +537,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               return
             }
 
-            try {
-              hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: stepDef.name, error: err })
-            } catch { /* hooks must not affect engine state */ }
+            await emit({ type: 'runFailed', runId: run.id, workflow: run.workflow, stepName: stepDef.name, error: err })
 
             if (wf.failureHandler) {
               try {
@@ -364,9 +562,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               return
             }
 
-            try {
-              hooks?.onRunFailed?.({ runId: run.id, workflow: run.workflow, stepName: result.branchName, error: result.error })
-            } catch { /* hooks must not affect engine state */ }
+            await emit({ type: 'runFailed', runId: run.id, workflow: run.workflow, stepName: result.branchName, error: result.error })
 
             if (wf.failureHandler) {
               try {
@@ -394,9 +590,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         return
       }
 
-      try {
-        hooks?.onRunComplete?.({ runId: run.id, workflow: run.workflow })
-      } catch { /* hooks must not affect engine state */ }
+      await emit({ type: 'runComplete', runId: run.id, workflow: run.workflow, output: prev })
     } finally {
       cleanupActiveRun(run.id)
     }
@@ -536,9 +730,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
     try {
       for (const branchDef of pendingBranches) {
-        try {
-          hooks?.onStepStart?.({ runId: run.id, stepName: branchDef.name })
-        } catch { /* hooks must not affect engine state */ }
+        await emit({ type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: branchDef.name })
       }
 
       const groupActiveRun: ActiveRunState = {
@@ -651,14 +843,14 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           throw new LeaseExpiredError(run.id)
         }
 
-        try {
-          hooks?.onStepComplete?.({
-            runId: run.id,
-            stepName: branchResult.name,
-            output: branchResult.output,
-            attempts: branchResult.attempts,
-          })
-        } catch { /* hooks must not affect engine state */ }
+        await emit({
+          type: 'stepComplete',
+          runId: run.id,
+          workflow: run.workflow,
+          stepName: branchResult.name,
+          output: branchResult.output,
+          attempts: branchResult.attempts,
+        })
 
         stepsAccumulator[branchResult.name] = structuredClone(branchResult.output)
         merged[branchResult.name] = branchResult.output
@@ -710,9 +902,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     const parsedInput = wf.parseInput(input)
     const scheduleId = randomUUID()
     const interval = setInterval(() => {
-      void enqueue(workflowName, parsedInput).catch((error) => {
-        try { hooks?.onError?.(error instanceof Error ? error : new Error(String(error))) } catch { /* hooks must not throw */ }
-      })
+      void enqueue(workflowName, parsedInput).catch(reportError)
     }, intervalMs)
 
     schedules.set(scheduleId, interval)
@@ -771,9 +961,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     running = true
 
     const triggerPoll = () => {
-      void runPollCycle().catch((error) => {
-        try { hooks?.onError?.(error instanceof Error ? error : new Error(String(error))) } catch { /* hooks must not throw */ }
-      })
+      void runPollCycle().catch(reportError)
     }
 
     triggerPoll()
@@ -805,6 +993,13 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
       abortActiveRun(runId, new RunControlError('Engine stopped'))
       cleanupActiveRun(runId)
     }
+
+    // End all streams and unblock any producer paused on backpressure, so a
+    // pending tick can settle instead of deadlocking on a consumer that is gone.
+    for (const subscriber of subscribers) {
+      subscriber.close()
+    }
+    subscribers.clear()
 
     if (tickPromise) {
       await tickPromise.catch(noop)
@@ -882,6 +1077,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     cancel,
     schedule,
     unschedule,
+    stream: createStream,
     tick,
     start,
     stop,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from 'node:crypto'
-import { persistedValuesEqual } from '../storage/codec'
+import { clonePersistedValue, persistedValuesEqual } from '../storage/codec'
+import {
+  createBoundedAsyncIterator,
+  type AbortableSubscriber,
+} from './async-iterator'
 import {
   ConfigError,
   DuplicateWorkflowError,
@@ -69,7 +73,8 @@ export interface StreamOptions {
    * Defaults to `Infinity` — events buffer without bound and the engine never
    * waits on the consumer. Set a finite value (e.g. `1`) to pace the engine
    * against a slow consumer; the engine will not start the next unit of work
-   * until the consumer drains the buffer below this size.
+   * until the consumer drains the buffer below this size. Set `0` for strict
+   * rendezvous delivery, where every event waits for a pending pull.
    */
   bufferSize?: number
 }
@@ -154,16 +159,9 @@ export interface Engine<TWorkflowMap extends Record<string, PersistedValue> = Re
 interface ActiveRunState {
   leaseId: string
   runAbortController: AbortController
+  observerAbortController: AbortController
   heartbeatTimer: ReturnType<typeof setInterval> | null
   heartbeatInFlight: boolean
-}
-
-/** A single {@link Engine.stream} consumer. */
-interface StreamSubscriber {
-  /** Deliver an event. Resolves once buffered; when the buffer is full, resolves only after the consumer drains it (backpressure). */
-  push(event: EngineEvent): Promise<void>
-  /** End the stream, unblocking any pending consumer and producer waiters. */
-  close(): void
 }
 
 /**
@@ -209,11 +207,12 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
   const registry = new Map<string, AnyWorkflow>()
   const schedules = new Map<string, ReturnType<typeof setInterval>>()
   const activeRuns = new Map<string, ActiveRunState>()
-  const subscribers = new Set<StreamSubscriber>()
+  const subscribers = new Set<AbortableSubscriber<EngineEvent>>()
   let running = false
   let timer: ReturnType<typeof setInterval> | null = null
   let tickInFlight = false
   let tickPromise: Promise<void> | null = null
+  let stopGeneration = 0
 
   for (const wf of workflows) {
     if (registry.has(wf.name)) {
@@ -270,35 +269,62 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
    * backpressured stream pace the engine. Neither a throwing hook nor a stream
    * may affect engine state, so all errors are contained.
    */
-  async function emit(event: EngineEvent): Promise<void> {
+  async function emit(event: EngineEvent, signal: AbortSignal): Promise<void> {
     try {
-      switch (event.type) {
-        case 'runStart':
-          await hooks?.onRunStart?.(event)
-          break
-        case 'stepStart':
-          await hooks?.onStepStart?.(event)
-          break
-        case 'stepComplete':
-          await hooks?.onStepComplete?.(event)
-          break
-        case 'runComplete':
-          await hooks?.onRunComplete?.(event)
-          break
-        case 'runFailed':
-          await hooks?.onRunFailed?.(event)
-          break
+      await runWithSignal(
+        () => Promise.resolve(dispatchHook(event)).then(noop),
+        signal,
+      )
+    } catch {
+      if (signal.aborted) {
+        throw toError(signal.reason)
       }
-    } catch { /* hooks must not affect engine state */ }
+      // Hooks are observers and must not affect engine state.
+    }
 
-    if (subscribers.size > 0) {
-      const deliveries: Array<Promise<void>> = []
-      for (const subscriber of subscribers) {
-        deliveries.push(subscriber.push(event))
+    if (subscribers.size === 0) {
+      return
+    }
+
+    const deliveries = Array.from(
+      subscribers,
+      (subscriber) => subscriber.push(cloneEngineEvent(event), signal),
+    )
+
+    try {
+      await runWithSignal(
+        () => Promise.allSettled(deliveries).then(noop),
+        signal,
+      )
+    } catch {
+      if (signal.aborted) {
+        throw toError(signal.reason)
       }
-      try {
-        await Promise.all(deliveries)
-      } catch { /* stream delivery must not affect engine state */ }
+      // Stream delivery is observational and must not affect engine state.
+    }
+  }
+
+  function dispatchHook(event: EngineEvent): unknown {
+    switch (event.type) {
+      case 'runStart':
+        return hooks?.onRunStart?.({ ...event })
+      case 'stepStart':
+        return hooks?.onStepStart?.({ ...event })
+      case 'stepComplete':
+        return hooks?.onStepComplete?.({
+          ...event,
+          output: clonePersistedValue(event.output, 'Step hook output'),
+        })
+      case 'runComplete':
+        return hooks?.onRunComplete?.({
+          ...event,
+          output: clonePersistedValue(event.output, 'Run hook output'),
+        })
+      case 'runFailed':
+        return hooks?.onRunFailed?.({
+          ...event,
+          error: cloneError(event.error),
+        })
     }
   }
 
@@ -314,89 +340,21 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
   function createStream(options?: StreamOptions): ResultStream {
     const capacity = options?.bufferSize ?? Number.POSITIVE_INFINITY
-    const buffer: EngineEvent[] = []
-    const pullWaiters: Array<(result: IteratorResult<EngineEvent>) => void> = []
-    const pushWaiters: Array<() => void> = []
-    let closed = false
-
-    const subscriber: StreamSubscriber = {
-      push(event) {
-        if (closed) return Promise.resolve()
-
-        const waiter = pullWaiters.shift()
-        if (waiter) {
-          waiter({ value: event, done: false })
-          return Promise.resolve()
-        }
-
-        buffer.push(event)
-        if (buffer.length <= capacity) {
-          return Promise.resolve()
-        }
-
-        // Buffer is over capacity — pause the producer until the consumer drains it.
-        return new Promise<void>((resolve) => pushWaiters.push(resolve))
-      },
-      close() {
-        if (closed) return
-        closed = true
-        for (const waiter of pullWaiters.splice(0)) {
-          waiter({ value: undefined, done: true })
-        }
-        for (const resume of pushWaiters.splice(0)) {
-          resume()
-        }
-      },
+    if (
+      capacity !== Number.POSITIVE_INFINITY &&
+      (!Number.isInteger(capacity) || capacity < 0)
+    ) {
+      throw new ConfigError('Stream bufferSize must be a non-negative integer or Infinity')
     }
 
+    let subscriber!: AbortableSubscriber<EngineEvent>
+    const channel = createBoundedAsyncIterator<EngineEvent>(
+      capacity,
+      () => subscribers.delete(subscriber),
+    )
+    subscriber = channel.subscriber
     subscribers.add(subscriber)
-
-    const dispose = (): void => {
-      subscribers.delete(subscriber)
-      closed = true
-      // Resolve a pending consumer (a manual next() awaiting an empty buffer) as
-      // done, and unblock any paused producer, so nothing is left hanging.
-      for (const waiter of pullWaiters.splice(0)) {
-        waiter({ value: undefined, done: true })
-      }
-      for (const resume of pushWaiters.splice(0)) {
-        resume()
-      }
-    }
-
-    const stream: ResultStream = {
-      next(): Promise<IteratorResult<EngineEvent>> {
-        const event = buffer.shift()
-        if (event !== undefined) {
-          const resume = pushWaiters.shift()
-          if (resume) resume()
-          return Promise.resolve({ value: event, done: false })
-        }
-
-        if (closed) {
-          return Promise.resolve({ value: undefined, done: true })
-        }
-
-        return new Promise<IteratorResult<EngineEvent>>((resolve) => pullWaiters.push(resolve))
-      },
-      return(): Promise<IteratorResult<EngineEvent>> {
-        dispose()
-        return Promise.resolve({ value: undefined, done: true })
-      },
-      throw(error?: unknown): Promise<IteratorResult<EngineEvent>> {
-        dispose()
-        return Promise.reject(error instanceof Error ? error : new Error(String(error)))
-      },
-      [Symbol.asyncIterator]() {
-        return stream
-      },
-      [Symbol.asyncDispose](): Promise<void> {
-        dispose()
-        return Promise.resolve()
-      },
-    }
-
-    return stream
+    return channel.iterator
   }
 
   async function executeRun(run: ClaimedRun): Promise<void> {
@@ -404,9 +362,15 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     if (!wf) return
 
     const activeRun = registerActiveRun(run)
+    const observerSignal = activeRun.observerAbortController.signal
 
     try {
-      await emit({ type: 'runStart', runId: run.id, workflow: run.workflow })
+      const currentRun = await storage.getRun(run.id)
+      if (!currentRun || currentRun.status !== 'running') {
+        return
+      }
+
+      await emit({ type: 'runStart', runId: run.id, workflow: run.workflow }, observerSignal)
 
       const existingSteps = await storage.getStepResults(run.id)
       const completedMap = new Map(existingSteps.map((step) => [step.name, step]))
@@ -433,14 +397,17 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               stepName: stepDef.name,
               output: existing.output,
               attempts: existing.attempts,
-            })
+            }, observerSignal)
 
             const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
             if (!completed) {
               throw new LeaseExpiredError(run.id)
             }
 
-            await emit({ type: 'runComplete', runId: run.id, workflow: run.workflow, output: existing.output })
+            await emit(
+              { type: 'runComplete', runId: run.id, workflow: run.workflow, output: existing.output },
+              observerSignal,
+            )
 
             return
           }
@@ -453,7 +420,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           const frozenSteps = snapshotSteps(stepsAccumulator)
 
           try {
-            await emit({ type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: stepDef.name })
+            await emit(
+              { type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: stepDef.name },
+              observerSignal,
+            )
 
             const outcome = await executeStep(run, activeRun, stepDef, prev, frozenSteps)
 
@@ -519,7 +489,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               stepName: stepDef.name,
               output: outcome.output,
               attempts: outcome.attempts,
-            })
+            }, observerSignal)
 
             if (outcome.kind === 'early-complete') {
               const completed = await storage.updateClaimedRunStatus(run.id, run.leaseId, 'completed')
@@ -527,7 +497,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
                 throw new LeaseExpiredError(run.id)
               }
 
-              await emit({ type: 'runComplete', runId: run.id, workflow: run.workflow, output: outcome.output })
+              await emit(
+                { type: 'runComplete', runId: run.id, workflow: run.workflow, output: outcome.output },
+                observerSignal,
+              )
 
               return
             }
@@ -557,7 +530,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               return
             }
 
-            await emit({ type: 'runFailed', runId: run.id, workflow: run.workflow, stepName: stepDef.name, error: err })
+            await emit(
+              { type: 'runFailed', runId: run.id, workflow: run.workflow, stepName: stepDef.name, error: err },
+              observerSignal,
+            )
 
             if (wf.failureHandler) {
               try {
@@ -582,7 +558,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
               return
             }
 
-            await emit({ type: 'runFailed', runId: run.id, workflow: run.workflow, stepName: result.branchName, error: result.error })
+            await emit(
+              { type: 'runFailed', runId: run.id, workflow: run.workflow, stepName: result.branchName, error: result.error },
+              observerSignal,
+            )
 
             if (wf.failureHandler) {
               try {
@@ -610,7 +589,14 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         return
       }
 
-      await emit({ type: 'runComplete', runId: run.id, workflow: run.workflow, output: prev })
+      await emit(
+        { type: 'runComplete', runId: run.id, workflow: run.workflow, output: prev },
+        observerSignal,
+      )
+    } catch (error) {
+      if (!(error instanceof RunControlError)) {
+        throw error
+      }
     } finally {
       cleanupActiveRun(run.id)
     }
@@ -750,7 +736,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
     try {
       for (const branchDef of pendingBranches) {
-        await emit({ type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: branchDef.name })
+        await emit(
+          { type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: branchDef.name },
+          activeRun.observerAbortController.signal,
+        )
       }
 
       const groupActiveRun: ActiveRunState = {
@@ -874,7 +863,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           stepName: branchResult.name,
           output: branchResult.output,
           attempts: branchResult.attempts,
-        })
+        }, activeRun.observerAbortController.signal)
 
         stepsAccumulator[branchResult.name] = structuredClone(branchResult.output)
         merged[branchResult.name] = branchResult.output
@@ -947,6 +936,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
       return
     }
 
+    const generation = stopGeneration
     tickInFlight = true
     const promise = (async () => {
       try {
@@ -960,6 +950,10 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
           }
 
           runs.push(run)
+        }
+
+        if (generation !== stopGeneration) {
+          return
         }
 
         await Promise.all(runs.map((run) => executeRun(run)))
@@ -1001,6 +995,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
   }
 
   async function stop(): Promise<void> {
+    stopGeneration++
     running = false
 
     if (timer) {
@@ -1039,6 +1034,7 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     const activeRun: ActiveRunState = {
       leaseId: run.leaseId,
       runAbortController: new AbortController(),
+      observerAbortController: new AbortController(),
       heartbeatTimer: null,
       heartbeatInFlight: false,
     }
@@ -1088,11 +1084,20 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
   function abortActiveRun(runId: string, reason: Error): void {
     const activeRun = activeRuns.get(runId)
-    if (!activeRun || activeRun.runAbortController.signal.aborted) {
+    if (!activeRun) {
       return
     }
 
-    activeRun.runAbortController.abort(reason)
+    if (!activeRun.runAbortController.signal.aborted) {
+      activeRun.runAbortController.abort(reason)
+    }
+
+    if (
+      reason instanceof RunControlError &&
+      !activeRun.observerAbortController.signal.aborted
+    ) {
+      activeRun.observerAbortController.abort(reason)
+    }
   }
 
   return {
@@ -1106,6 +1111,35 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
     start,
     stop,
   } as Engine<WorkflowInputMap<TWorkflows>>
+}
+
+function cloneEngineEvent(event: EngineEvent): EngineEvent {
+  switch (event.type) {
+    case 'stepComplete':
+      return {
+        ...event,
+        output: clonePersistedValue(event.output, 'Step event output'),
+      }
+    case 'runComplete':
+      return {
+        ...event,
+        output: clonePersistedValue(event.output, 'Run event output'),
+      }
+    case 'runFailed':
+      return {
+        ...event,
+        error: cloneError(event.error),
+      }
+    default:
+      return { ...event }
+  }
+}
+
+function cloneError(error: Error): Error {
+  return Object.create(
+    Object.getPrototypeOf(error),
+    Object.getOwnPropertyDescriptors(error),
+  ) as Error
 }
 
 function runWithSignal<T>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,16 @@ export type {
   WorkflowInputMap,
   WorkflowStepsMap,
 } from './core/workflow'
-export type { Engine, EngineConfig, EngineHooks, EnqueueOptions } from './core/engine'
+export type {
+  Engine,
+  EngineConfig,
+  EngineHooks,
+  EngineEvent,
+  EngineEventOf,
+  EnqueueOptions,
+  StreamOptions,
+  ResultStream,
+} from './core/engine'
 export type {
   ClaimedRun,
   CreateRunResult,


### PR DESCRIPTION
## Summary

Adds a pull-based result stream and makes lifecycle hooks awaitable — two synergistic features built on one unified event pipeline.

### `engine.stream()` (closes #24)

A pull-based, backpressure-aware alternative to push-based hooks, replacing the hand-rolled queue + waiter + permit plumbing the issue describes.

```ts
for await (const event of engine.stream()) {
  if (event.type === 'runComplete') await pipeline.push(event.output)
}
```

- Returns an `AsyncIterableIterator<EngineEvent>` (also `AsyncDisposable`). `EngineEvent` is a discriminated union on `type`: `runStart` / `stepStart` / `stepComplete` / `runComplete` / `runFailed`, each carrying `runId` + `workflow`.
- Optional `bufferSize` applies backpressure — the engine pauses once the buffer fills and resumes as the consumer pulls. Default is unbounded (never slows the engine).
- Cleanup is automatic: breaking out of `for await`, `await using`, or `engine.stop()` unsubscribes the stream.

### Async hooks (closes #23)

Lifecycle hooks may now be `async` and are awaited before the engine proceeds, so a hook can flush a metric, persist an audit row, or apply ordering/backpressure. Throwing or rejecting hooks remain fully contained and never affect engine state.

### Internals

Hook dispatch and stream delivery now flow through a single internal `emit` pipeline. Event objects gained a `type` discriminator and `workflow`; `onStepStart`/`onStepComplete` now include `workflow` and `onRunComplete` includes the workflow's final `output`. These are **additive** — existing hook callbacks type-check and run unchanged (return types stay `void` to preserve void-lenience for sync hooks that incidentally return a value).

New exports: `EngineEvent`, `EngineEventOf`, `StreamOptions`, `ResultStream`.

> Note: issue #21 (conditional steps / caching) is intentionally **not** included — it needs its own type-safe design and will be a separate PR.

## Test plan

- 11 new tests in `src/core/__tests__/stream.test.ts` covering ordering, final output, multi-workflow tagging, backpressure (engine pause/resume), auto-unsubscribe on break, `await using` disposal, stop-closes-streams, and contained rejecting async hooks.
- Existing hook tests updated for the enriched event shapes.

- [x] Tests pass (`bun run test`) — 305 passing
- [x] Type checking passes (`bun run typecheck`)
- [x] Build + package export check (`attw`) pass

---

**Credit:** both features were proposed by [@brianjenkins94](https://github.com/brianjenkins94) — async hooks in #23 and the result stream in #24. Thank you!
