### PR TITLE
feat: node:sqlite storage adapter (zero native deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,15 @@ jobs:
           }
           await stream[Symbol.asyncDispose]()
           EOF
+
+  node-sqlite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: bun install
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+      - name: Run the node:sqlite adapter tests on Node
+        run: node node_modules/.bin/vitest run src/storage/__tests__/sqlite-node-builtin.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **`engine.stream()`** — a pull-based, backpressure-aware stream of execution events. Returns an `AsyncIterableIterator<EngineEvent>` (also an `AsyncDisposable`) so you can `for await` over `runStart` / `stepStart` / `stepComplete` / `runComplete` / `runFailed` events instead of wiring up callback-to-queue plumbing. Optional `bufferSize` paces the engine against a slow consumer; breaking out of the loop, `await using`, or `engine.stop()` unsubscribes automatically. New exported types: `EngineEvent`, `EngineEventOf`, `StreamOptions`, `ResultStream`. ([#24](https://github.com/danfry1/reflow-ts/issues/24) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
 - **Async hooks** — lifecycle hooks may now be `async` and are awaited before the engine proceeds, so a hook can flush a metric, persist an audit row, or apply backpressure with ordering guarantees. A throwing or rejecting hook is still fully contained and never affects engine state. ([#23](https://github.com/danfry1/reflow-ts/issues/23) — suggested by [@brianjenkins94](https://github.com/brianjenkins94))
+- **`reflow-ts/sqlite-node-builtin`** — a new SQLite storage adapter for Node.js backed by the built-in `node:sqlite` module, with **zero native dependencies** (the Node equivalent of the Bun adapter). Requires Node ≥ 22.5; the existing `better-sqlite3`-based `reflow-ts/sqlite-node` adapter remains for Node ≥ 18.18.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -511,6 +511,14 @@ import { SQLiteStorage } from 'reflow-ts/sqlite-node'
 const storage = new SQLiteStorage('./workflows.db')
 ```
 
+**SQLiteStorage** — for Node.js with **no native dependencies**, using the built-in `node:sqlite` module (Node ≥ 22.5). The Node equivalent of the Bun adapter.
+
+```typescript
+import { SQLiteStorage } from 'reflow-ts/sqlite-node-builtin'
+
+const storage = new SQLiteStorage('./workflows.db')
+```
+
 **MemoryStorage** — used internally by the test helper. For custom use, import from `reflow-ts/test`.
 
 ```typescript
@@ -787,6 +795,10 @@ SQLite storage adapter for Bun runtime. Uses the built-in `bun:sqlite` module �
 ### `SQLiteStorage(path)` — Node.js
 
 SQLite storage adapter for Node.js. Uses `better-sqlite3`. WAL mode and transactional claiming.
+
+### `SQLiteStorage(path)` — Node.js built-in
+
+SQLite storage adapter for Node.js using the built-in `node:sqlite` module — no native dependencies. Requires Node ≥ 22.5 (`--experimental-sqlite` before Node 23.4). WAL mode and transactional claiming. Import from `reflow-ts/sqlite-node-builtin`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/storage/sqlite-bun.d.mts",
       "import": "./dist/storage/sqlite-bun.mjs"
     },
+    "./sqlite-node-builtin": {
+      "types": "./dist/storage/sqlite-node-builtin.d.mts",
+      "import": "./dist/storage/sqlite-node-builtin.mjs"
+    },
     "./test": {
       "types": "./dist/test/index.d.mts",
       "import": "./dist/test/index.mjs"

--- a/src/storage/__tests__/sqlite-node-builtin.test.ts
+++ b/src/storage/__tests__/sqlite-node-builtin.test.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from 'node:crypto'
+import { existsSync, unlinkSync } from 'node:fs'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { StepResult, WorkflowRun } from '../../core/types'
+import { SQLiteStorage } from '../sqlite-node-builtin'
+
+// node:sqlite was added in Node 22.5 and is unavailable on Bun / older Node.
+// Skip the whole suite where it can't load so the default (Bun) test run is green;
+// the dedicated Node CI job exercises it for real.
+const nodeSqliteAvailable = await import('node:sqlite').then(() => true, () => false)
+
+function expectPresent<T>(value: T | null | undefined): T {
+  expect(value).not.toBeNull()
+  expect(value).not.toBeUndefined()
+  if (value == null) {
+    throw new Error('Expected value to be present')
+  }
+  return value
+}
+
+function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  const now = Date.now()
+  return {
+    id: 'run_1',
+    workflow: 'test',
+    input: {},
+    idempotencyKey: null,
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function makeStep(overrides: Partial<StepResult> = {}): StepResult {
+  const now = Date.now()
+  return {
+    id: 'step_1',
+    runId: 'run_1',
+    name: 'step-a',
+    status: 'completed',
+    output: { result: true },
+    error: null,
+    attempts: 1,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+describe.skipIf(!nodeSqliteAvailable)('SQLiteStorage (node:sqlite)', () => {
+  let dbPath: string
+  let storage: SQLiteStorage
+
+  beforeEach(async () => {
+    dbPath = `/tmp/reflow-nodesqlite-${randomUUID()}.db`
+    storage = new SQLiteStorage(dbPath)
+    await storage.initialize()
+  })
+
+  afterEach(() => {
+    storage.close()
+    for (const suffix of ['', '-wal', '-shm', '-journal']) {
+      const path = `${dbPath}${suffix}`
+      if (existsSync(path)) unlinkSync(path)
+    }
+  })
+
+  it('initialize is idempotent', async () => {
+    await expect(storage.initialize()).resolves.toBeUndefined()
+  })
+
+  it('creates and reads back a run', async () => {
+    const run = makeRun()
+    const { run: stored, created } = await storage.createRun(run)
+    expect(created).toBe(true)
+    expect(stored.id).toBe('run_1')
+
+    const fetched = expectPresent(await storage.getRun('run_1'))
+    expect(fetched.workflow).toBe('test')
+    expect(fetched.status).toBe('pending')
+  })
+
+  it('returns null for a missing run', async () => {
+    expect(await storage.getRun('nope')).toBeNull()
+  })
+
+  it('round-trips a Date in the input', async () => {
+    const when = new Date('2026-01-02T03:04:05.000Z')
+    await storage.createRun(makeRun({ input: { when } }))
+    const fetched = expectPresent(await storage.getRun('run_1'))
+    const input = fetched.input as { when: Date }
+    expect(input.when).toBeInstanceOf(Date)
+    expect(input.when.toISOString()).toBe(when.toISOString())
+  })
+
+  it('idempotency: same key + workflow returns the existing run without duplicating', async () => {
+    const first = await storage.createRun(makeRun({ id: 'a', idempotencyKey: 'k' }))
+    expect(first.created).toBe(true)
+
+    const second = await storage.createRun(makeRun({ id: 'b', idempotencyKey: 'k' }))
+    expect(second.created).toBe(false)
+    expect(second.run.id).toBe('a') // the original, not 'b'
+  })
+
+  it('claims a pending run and returns a lease', async () => {
+    await storage.createRun(makeRun())
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+    expect(claimed.id).toBe('run_1')
+    expect(claimed.status).toBe('running')
+    expect(claimed.leaseId).toBeTruthy()
+
+    // A second claim finds nothing — the run is no longer pending.
+    expect(await storage.claimNextRun(['test'])).toBeNull()
+  })
+
+  it('returns null when there is nothing to claim', async () => {
+    expect(await storage.claimNextRun(['test'])).toBeNull()
+    expect(await storage.claimNextRun([])).toBeNull()
+  })
+
+  it('reclaims a stale running run but not a fresh one', async () => {
+    await storage.createRun(makeRun())
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+    // Fresh: not reclaimable when staleBefore is in the past.
+    expect(await storage.claimNextRun(['test'], Date.now() - 60_000)).toBeNull()
+
+    // Stale: reclaimable when staleBefore is in the future.
+    const reclaimed = expectPresent(await storage.claimNextRun(['test'], Date.now() + 60_000))
+    expect(reclaimed.id).toBe('run_1')
+    expect(reclaimed.leaseId).not.toBe(claimed.leaseId) // a new lease
+  })
+
+  it('heartbeat succeeds with the held lease and fails otherwise', async () => {
+    await storage.createRun(makeRun())
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+    expect(await storage.heartbeatRun('run_1', claimed.leaseId)).toBe(true)
+    expect(await storage.heartbeatRun('run_1', 'wrong-lease')).toBe(false)
+  })
+
+  it('saves and reads step results in creation order', async () => {
+    await storage.createRun(makeRun())
+    await storage.saveStepResult(makeStep({ id: 's1', name: 'a', createdAt: 1 }))
+    await storage.saveStepResult(makeStep({ id: 's2', name: 'b', createdAt: 2 }))
+
+    const steps = await storage.getStepResults('run_1')
+    expect(steps.map((s) => s.name)).toEqual(['a', 'b'])
+    expect(steps[0].output).toEqual({ result: true })
+  })
+
+  it('persists an undefined step output', async () => {
+    await storage.createRun(makeRun())
+    await storage.saveStepResult(makeStep({ output: undefined }))
+    const steps = await storage.getStepResults('run_1')
+    expect(steps[0].output).toBeUndefined()
+  })
+
+  it('upserts a step result on the same id', async () => {
+    await storage.createRun(makeRun())
+    await storage.saveStepResult(makeStep({ id: 's', status: 'failed', error: 'boom', output: null }))
+    await storage.saveStepResult(makeStep({ id: 's', status: 'completed', error: null, output: { ok: 1 } }))
+
+    const steps = await storage.getStepResults('run_1')
+    expect(steps).toHaveLength(1)
+    expect(steps[0].status).toBe('completed')
+    expect(steps[0].output).toEqual({ ok: 1 })
+  })
+
+  it('saveStepResult honors the lease check', async () => {
+    await storage.createRun(makeRun())
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+    expect(await storage.saveStepResult(makeStep({ id: 's1' }), claimed.leaseId)).toBe(true)
+    expect(await storage.saveStepResult(makeStep({ id: 's2' }), 'wrong-lease')).toBe(false)
+
+    const steps = await storage.getStepResults('run_1')
+    expect(steps.map((s) => s.id)).toEqual(['s1'])
+  })
+
+  it('updateRunStatus updates status and clears the lease', async () => {
+    await storage.createRun(makeRun())
+    await storage.claimNextRun(['test'])
+
+    expect(await storage.updateRunStatus('run_1', 'cancelled')).toBe(true)
+    const run = expectPresent(await storage.getRun('run_1'))
+    expect(run.status).toBe('cancelled')
+
+    // Lease was cleared, so a claimed-status update no longer applies.
+    expect(await storage.updateClaimedRunStatus('run_1', 'any', 'completed')).toBe(false)
+  })
+
+  it('updateClaimedRunStatus only applies with the matching lease', async () => {
+    await storage.createRun(makeRun())
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+    expect(await storage.updateClaimedRunStatus('run_1', 'wrong', 'completed')).toBe(false)
+    expect(await storage.updateClaimedRunStatus('run_1', claimed.leaseId, 'completed')).toBe(true)
+
+    const run = expectPresent(await storage.getRun('run_1'))
+    expect(run.status).toBe('completed')
+  })
+})

--- a/src/storage/sqlite-node-builtin.ts
+++ b/src/storage/sqlite-node-builtin.ts
@@ -1,0 +1,390 @@
+/**
+ * SQLite storage adapter for Node.js using the built-in `node:sqlite` module.
+ * No native dependencies required — unlike the `better-sqlite3`-backed
+ * `reflow-ts/sqlite-node` adapter.
+ *
+ * Requires **Node.js >= 22.5** (when `node:sqlite` was added). On Node 22.x and
+ * 23.x before 23.4 it is gated behind the `--experimental-sqlite` flag; from
+ * Node 23.4 it is available by default (still experimental). On older Node, or
+ * on Bun, use `reflow-ts/sqlite-node` or `reflow-ts/sqlite-bun` instead.
+ *
+ * @example
+ * ```ts
+ * import { SQLiteStorage } from 'reflow-ts/sqlite-node-builtin'
+ *
+ * const storage = new SQLiteStorage('./reflow.db')
+ * await storage.initialize()
+ * ```
+ */
+
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import type { DatabaseSync, StatementSync } from 'node:sqlite'
+import type {
+  ClaimedRun,
+  CreateRunResult,
+  RunStatus,
+  StepResult,
+  StorageAdapter,
+  WorkflowRun,
+} from '../core/types'
+import { deserializePersistedValue, serializePersistedValue } from './codec'
+
+// `node:sqlite` is loaded lazily through createRequire so importing this module
+// is safe on any runtime — only constructing SQLiteStorage requires the module
+// to be present (Node >= 22.5).
+const nodeRequire = createRequire(import.meta.url)
+
+interface WorkflowRunRow {
+  id: string
+  workflow: string
+  input: string
+  idempotency_key: string | null
+  lease_id: string | null
+  status: string
+  created_at: number
+  updated_at: number
+}
+
+interface WorkflowStepRow {
+  id: string
+  run_id: string
+  name: string
+  status: string
+  output: string | null
+  error: string | null
+  attempts: number
+  created_at: number
+  updated_at: number
+}
+
+export class SQLiteStorage implements StorageAdapter {
+  private db: DatabaseSync
+
+  constructor(path: string) {
+    const sqlite = nodeRequire('node:sqlite') as typeof import('node:sqlite')
+    this.db = new sqlite.DatabaseSync(path)
+    this.db.exec('PRAGMA journal_mode = WAL')
+    this.db.exec('PRAGMA synchronous = NORMAL')
+    this.db.exec('PRAGMA busy_timeout = 5000')
+  }
+
+  async initialize(): Promise<void> {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS workflow_runs (
+        id               TEXT PRIMARY KEY,
+        workflow         TEXT NOT NULL,
+        input            TEXT NOT NULL,
+        idempotency_key  TEXT,
+        lease_id         TEXT,
+        status           TEXT NOT NULL,
+        created_at       INTEGER NOT NULL,
+        updated_at       INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workflow_steps (
+        id          TEXT PRIMARY KEY,
+        run_id      TEXT NOT NULL,
+        name        TEXT NOT NULL,
+        status      TEXT NOT NULL,
+        output      TEXT,
+        error       TEXT,
+        attempts    INTEGER DEFAULT 0,
+        created_at  INTEGER NOT NULL,
+        updated_at  INTEGER NOT NULL
+      );
+    `)
+
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status, workflow);
+      CREATE INDEX IF NOT EXISTS idx_steps_run_id ON workflow_steps(run_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_workflow_idempotency
+      ON workflow_runs(workflow, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+    `)
+  }
+
+  async createRun(run: WorkflowRun): Promise<CreateRunResult> {
+    const findExistingRun = (): WorkflowRunRow | null => {
+      if (!run.idempotencyKey) {
+        return null
+      }
+
+      return this.get<WorkflowRunRow>(
+        `SELECT * FROM workflow_runs
+         WHERE workflow = ? AND idempotency_key = ?
+         LIMIT 1`,
+        run.workflow,
+        run.idempotencyKey,
+      )
+    }
+
+    return this.transaction((): CreateRunResult => {
+      const existing = findExistingRun()
+      if (existing) {
+        return {
+          run: mapWorkflowRunRow(existing),
+          created: false,
+        }
+      }
+
+      const serializedInput = serializePersistedValue(run.input, 'Workflow input')
+
+      try {
+        this.db
+          .prepare(
+            `INSERT INTO workflow_runs (id, workflow, input, idempotency_key, lease_id, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, NULL, ?, ?, ?)`,
+          )
+          .run(
+            run.id,
+            run.workflow,
+            serializedInput,
+            run.idempotencyKey,
+            run.status,
+            run.createdAt,
+            run.updatedAt,
+          )
+      } catch (error) {
+        if (run.idempotencyKey && isUniqueConstraintError(error)) {
+          const racedExisting = findExistingRun()
+          if (racedExisting) {
+            return {
+              run: mapWorkflowRunRow(racedExisting),
+              created: false,
+            }
+          }
+        }
+
+        throw error
+      }
+
+      return {
+        run: {
+          ...run,
+          input: deserializePersistedValue(serializedInput),
+        },
+        created: true,
+      }
+    })
+  }
+
+  async claimNextRun(workflowNames: readonly string[], staleBefore?: number): Promise<ClaimedRun | null> {
+    if (workflowNames.length === 0) {
+      return null
+    }
+
+    const placeholders = workflowNames.map(() => '?').join(', ')
+
+    return this.transaction(() => {
+      const reclaimClause = staleBefore === undefined
+        ? `status = 'pending'`
+        : `(status = 'pending' OR (status = 'running' AND updated_at <= ?))`
+      const queryArgs = staleBefore === undefined
+        ? [...workflowNames]
+        : [...workflowNames, staleBefore]
+
+      const row = this.get<WorkflowRunRow>(
+        `SELECT * FROM workflow_runs
+         WHERE workflow IN (${placeholders}) AND ${reclaimClause}
+         ORDER BY CASE status WHEN 'pending' THEN 0 ELSE 1 END ASC, created_at ASC, rowid ASC
+         LIMIT 1`,
+        ...queryArgs,
+      )
+
+      if (!row) {
+        return null
+      }
+
+      const now = Date.now()
+      const leaseId = randomUUID()
+      const updateWhere = staleBefore === undefined
+        ? `id = ? AND status = 'pending'`
+        : `id = ? AND (status = 'pending' OR (status = 'running' AND updated_at <= ?))`
+      const updateArgs = staleBefore === undefined
+        ? [leaseId, now, row.id]
+        : [leaseId, now, row.id, staleBefore]
+
+      const changes = this.run(
+        `UPDATE workflow_runs
+         SET status = 'running', lease_id = ?, updated_at = ?
+         WHERE ${updateWhere}`,
+        ...updateArgs,
+      )
+
+      if (changes === 0) {
+        return null
+      }
+
+      return {
+        ...mapWorkflowRunRow(row),
+        status: 'running' as RunStatus,
+        updatedAt: now,
+        leaseId,
+      }
+    })
+  }
+
+  async heartbeatRun(runId: string, leaseId: string): Promise<boolean> {
+    const changes = this.run(
+      `UPDATE workflow_runs
+       SET updated_at = ?
+       WHERE id = ? AND status = 'running' AND lease_id = ?`,
+      Date.now(),
+      runId,
+      leaseId,
+    )
+
+    return changes > 0
+  }
+
+  async getRun(runId: string): Promise<WorkflowRun | null> {
+    const row = this.get<WorkflowRunRow>(`SELECT * FROM workflow_runs WHERE id = ?`, runId)
+    return row ? mapWorkflowRunRow(row) : null
+  }
+
+  async getStepResults(runId: string): Promise<StepResult[]> {
+    const rows = this.all<WorkflowStepRow>(
+      `SELECT * FROM workflow_steps WHERE run_id = ? ORDER BY created_at ASC`,
+      runId,
+    )
+
+    return rows.map((row): StepResult => ({
+      id: row.id,
+      runId: row.run_id,
+      name: row.name,
+      status: row.status as StepResult['status'],
+      output: row.output === null ? null : deserializePersistedValue(row.output),
+      error: row.error,
+      attempts: row.attempts,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }))
+  }
+
+  async saveStepResult(result: StepResult, leaseId?: string): Promise<boolean> {
+    return this.transaction(() => {
+      if (leaseId) {
+        const run = this.get<{ _: number }>(
+          `SELECT 1 AS _ FROM workflow_runs
+           WHERE id = ? AND status = 'running' AND lease_id = ?`,
+          result.runId,
+          leaseId,
+        )
+
+        if (!run) {
+          return false
+        }
+      }
+
+      this.run(
+        `INSERT OR REPLACE INTO workflow_steps (id, run_id, name, status, output, error, attempts, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        result.id,
+        result.runId,
+        result.name,
+        result.status,
+        serializePersistedValue(result.output, 'Step output'),
+        result.error,
+        result.attempts,
+        result.createdAt,
+        result.updatedAt,
+      )
+
+      return true
+    })
+  }
+
+  async updateRunStatus(runId: string, status: RunStatus): Promise<boolean> {
+    const changes = this.run(
+      `UPDATE workflow_runs
+       SET status = ?, lease_id = ?, updated_at = ?
+       WHERE id = ?`,
+      status,
+      null,
+      Date.now(),
+      runId,
+    )
+
+    return changes > 0
+  }
+
+  async updateClaimedRunStatus(runId: string, leaseId: string, status: RunStatus): Promise<boolean> {
+    const changes = this.run(
+      `UPDATE workflow_runs
+       SET status = ?, lease_id = ?, updated_at = ?
+       WHERE id = ? AND status = 'running' AND lease_id = ?`,
+      status,
+      status === 'running' ? leaseId : null,
+      Date.now(),
+      runId,
+      leaseId,
+    )
+
+    return changes > 0
+  }
+
+  close(): void {
+    this.db.close()
+  }
+
+  // --- node:sqlite helpers -------------------------------------------------
+  // node:sqlite has no transaction() helper and run() returns { changes },
+  // so these wrap the StatementSync API to match the shape the methods expect.
+
+  private prepare(sql: string): StatementSync {
+    return this.db.prepare(sql)
+  }
+
+  private get<T>(sql: string, ...params: SqlParam[]): T | null {
+    return (this.prepare(sql).get(...params) as T | undefined) ?? null
+  }
+
+  private all<T>(sql: string, ...params: SqlParam[]): T[] {
+    return this.prepare(sql).all(...params) as T[]
+  }
+
+  private run(sql: string, ...params: SqlParam[]): number {
+    return Number(this.prepare(sql).run(...params).changes)
+  }
+
+  private transaction<T>(fn: () => T): T {
+    this.db.exec('BEGIN')
+    try {
+      const result = fn()
+      this.db.exec('COMMIT')
+      return result
+    } catch (error) {
+      this.db.exec('ROLLBACK')
+      throw error
+    }
+  }
+}
+
+// node:sqlite binds null as a value but typings model it via SupportedValueType.
+type SqlParam = string | number | bigint | null | Uint8Array
+
+function mapWorkflowRunRow(row: WorkflowRunRow): WorkflowRun {
+  return {
+    id: row.id,
+    workflow: row.workflow,
+    input: deserializePersistedValue(row.input),
+    idempotencyKey: row.idempotency_key,
+    status: row.status as RunStatus,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const code = (error as { code?: string }).code
+  const errcode = (error as { errcode?: number }).errcode
+  return code === 'SQLITE_CONSTRAINT_UNIQUE'
+    || errcode === 2067 // SQLITE_CONSTRAINT_UNIQUE (extended result code)
+    || errcode === 19 // SQLITE_CONSTRAINT (primary result code)
+    || error.message.includes('UNIQUE constraint failed')
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,11 +5,12 @@ export default defineConfig({
     index: 'src/index.ts',
     'storage/sqlite-node': 'src/storage/sqlite-node.ts',
     'storage/sqlite-bun': 'src/storage/sqlite-bun.ts',
+    'storage/sqlite-node-builtin': 'src/storage/sqlite-node-builtin.ts',
     'test/index': 'src/test/index.ts',
   },
   format: 'esm',
   dts: true,
   sourcemap: true,
   clean: true,
-  deps: { neverBundle: ['better-sqlite3', 'bun:sqlite'] },
+  deps: { neverBundle: ['better-sqlite3', 'bun:sqlite', 'node:sqlite'] },
 })

--- a/website/api/storage.md
+++ b/website/api/storage.md
@@ -18,7 +18,16 @@ const storage = new SQLiteStorage('./workflows.db')
 
 SQLite adapter for Node.js. Uses [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) (an optional peer dependency). WAL mode with transactional claiming.
 
-Both constructors take a database file path. Pass `:memory:` for an ephemeral database.
+## `SQLiteStorage` — Node.js built-in
+
+```typescript
+import { SQLiteStorage } from 'reflow-ts/sqlite-node-builtin'
+const storage = new SQLiteStorage('./workflows.db')
+```
+
+SQLite adapter for Node.js using the built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html) module — no native dependencies. Requires **Node.js ≥ 22.5** (`--experimental-sqlite` before Node 23.4). WAL mode with transactional claiming. See [Storage › Node built-in](/guide/storage#sqlitestorage-node-js-built-in).
+
+All three SQLite constructors take a database file path. Pass `:memory:` for an ephemeral database.
 
 ## `MemoryStorage`
 

--- a/website/guide/storage.md
+++ b/website/guide/storage.md
@@ -22,6 +22,22 @@ import { SQLiteStorage } from 'reflow-ts/sqlite-node'
 const storage = new SQLiteStorage('./workflows.db')
 ```
 
+## SQLiteStorage (Node.js built-in)
+
+For modern Node.js with **zero native dependencies** — uses the built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html) module instead of `better-sqlite3`, the Node equivalent of the Bun adapter.
+
+```typescript
+import { SQLiteStorage } from 'reflow-ts/sqlite-node-builtin'
+
+const storage = new SQLiteStorage('./workflows.db')
+```
+
+Requires **Node.js ≥ 22.5** (when `node:sqlite` landed). On Node 22.x and 23.x before 23.4 it's gated behind the `--experimental-sqlite` flag; from Node 23.4 it's on by default (still experimental, so Node prints an `ExperimentalWarning`). For Node below 22.5, use the `better-sqlite3` adapter above.
+
+::: tip Which Node adapter?
+Use `sqlite-node-builtin` if you're on Node ≥ 22.5 and want to drop the `better-sqlite3` native dependency. Use `sqlite-node` for broad compatibility (Node ≥ 18.18) or to avoid the experimental module.
+:::
+
 ## MemoryStorage
 
 An in-memory adapter, used internally by the [test helper](/guide/testing). For custom use, import it from `reflow-ts/test`. State is lost when the process exits — it offers no durability, so it's for tests and ephemeral work only.


### PR DESCRIPTION
## Summary

Adds **`reflow-ts/sqlite-node-builtin`** — a SQLite storage adapter for Node.js backed by the built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html) module, with **zero native dependencies**. It's the Node counterpart to the `bun:sqlite` adapter and an alternative to the `better-sqlite3`-based `sqlite-node` adapter.

> **Stacked on #37** (base = `docs/vitepress-migration`, which is itself on #36) so it can document the adapter in the VitePress docs. Merge the stack in order, or retarget after the parents land.

### What's here
- **`src/storage/sqlite-node-builtin.ts`** — same schema/SQL as the other SQLite adapters. `node:sqlite` is loaded lazily via `createRequire`, so the module imports safely on any runtime and only **construction** requires Node ≥ 22.5. Wraps `node:sqlite`'s driver shape: `run()` → `{ changes }`, manual `BEGIN/COMMIT/ROLLBACK` transactions, `get()` `undefined` → `null`.
- New export path `reflow-ts/sqlite-node-builtin` + tsdown entry + `attw` clean.
- **Tests** — full `StorageAdapter` contract (create/idempotency, claim + stale reclaim, heartbeat, lease-checked saves, status updates, `Date` round-trip), `describe.skipIf` when `node:sqlite` is unavailable.
- **CI** — new `node-sqlite` job runs the suite on **Node 24**. (The default Bun `test` job also exercises it, since Bun implements `node:sqlite`.)
- Docs (VitePress storage guide + API), README, and CHANGELOG updated.

The `better-sqlite3` adapter (`reflow-ts/sqlite-node`) stays for Node ≥ 18.18 and for anyone avoiding the experimental module.

## Why
Mirrors how the Bun adapter uses built-in `bun:sqlite` — lets Node ≥ 22.5 users drop the `better-sqlite3` native addon. Additive, not a replacement (`node:sqlite` needs 22.5+; reflow's floor is 18.18).

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 360 passing (15 new)
- [x] Adapter suite verified on **real Node 24** (`node:sqlite`, with the expected `ExperimentalWarning`) and under Bun
- [x] `bun run build` + `attw` — new entry + types resolve
- [x] `bun run build:website` — docs build clean