### PR TITLE
chore: supply-chain hardening for releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    # Supply-chain hardening: hold update PRs until a version has been public for
+    # at least seven days, long enough for most malicious releases to be yanked.
+    # Mirrors the install-time minimumReleaseAge gate in bunfig.toml.
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
     groups:
       dev-dependencies:
         dependency-type: development
@@ -20,3 +28,5 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
+      - name: Verify dependencies are pinned
+        run: bun run lint:deps
       - run: bun run typecheck
       - run: bun run test -- --coverage
       - run: bun run build
@@ -24,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - run: bun run build
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -64,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,19 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # npm >= 11.15 is required for staged publishing (`npm stage`).
+      - run: npm i -g npm@11.15.0
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Verify dependencies are pinned
+        run: bun run lint:deps
 
       - name: Typecheck
         run: bun run typecheck
@@ -44,11 +50,18 @@ jobs:
 
       - name: Check package exports
         run: |
-          npm pack --pack-destination /tmp
+          npm pack --ignore-scripts --pack-destination /tmp
           npx --yes @arethetypeswrong/cli /tmp/reflow-ts-*.tgz --ignore-rules cjs-resolves-to-esm no-resolution
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - name: Stage publish to npm
+        # Uploads the tarball to npm's stage queue. Provenance is auto-generated
+        # via OIDC trusted publishing (id-token: write). The version is NOT
+        # installable until a maintainer approves it with a 2FA challenge:
+        #   npm stage approve <id>   (or approve on npmjs.com)
+        run: npm stage publish
+
+      - name: Staged-publish approval reminder
+        run: echo "::notice::Version staged to npm. Approve it (npm stage approve <id>, or on npmjs.com) with 2FA to make it installable."
 
       - name: Create GitHub Release
         env:

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -1,0 +1,21 @@
+{
+  "versionGroups": [
+    {
+      "label": "better-sqlite3 is intentionally a wide peer range + a pinned dev version",
+      "dependencies": ["better-sqlite3"],
+      "isIgnored": true
+    }
+  ],
+  "semverGroups": [
+    {
+      "label": "devDependencies are pinned to exact versions (supply-chain hardening)",
+      "dependencyTypes": ["dev"],
+      "range": ""
+    },
+    {
+      "label": "runtime + peer deps keep author-defined ranges so consumers can dedupe",
+      "dependencyTypes": ["prod", "peer"],
+      "isIgnored": true
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,14 +8,15 @@
         "@standard-schema/spec": "^1.1.0",
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.13",
-        "@vitest/coverage-v8": "^4.0.18",
-        "better-sqlite3": "^12.6.2",
-        "tsdown": "^0.21.0",
-        "typescript": "^5.9.3",
-        "vitepress": "^1.6.4",
-        "vitest": "^4.0.18",
-        "zod": "^4.3.6",
+        "@types/better-sqlite3": "7.6.13",
+        "@vitest/coverage-v8": "4.0.18",
+        "better-sqlite3": "12.6.2",
+        "syncpack": "15.3.1",
+        "tsdown": "0.21.2",
+        "typescript": "5.9.3",
+        "vitepress": "1.6.4",
+        "vitest": "4.0.18",
+        "zod": "4.3.6",
       },
       "peerDependencies": {
         "better-sqlite3": ">=9.0.0",
@@ -569,6 +570,24 @@
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "syncpack": ["syncpack@15.3.1", "", { "optionalDependencies": { "syncpack-darwin-arm64": "15.3.1", "syncpack-darwin-x64": "15.3.1", "syncpack-linux-arm64": "15.3.1", "syncpack-linux-arm64-musl": "15.3.1", "syncpack-linux-x64": "15.3.1", "syncpack-linux-x64-musl": "15.3.1", "syncpack-windows-arm64": "15.3.1", "syncpack-windows-x64": "15.3.1" }, "bin": { "syncpack": "index.cjs" } }, "sha512-0Z+/rwbskj+m5qW8caVbd59OwwXBcxRiDFk82Cb4tKGLPXmZn7Vjo7BnfxHwZqS51Ff+5TFgH5/iyXd24+G6YA=="],
+
+    "syncpack-darwin-arm64": ["syncpack-darwin-arm64@15.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvbaowC/fw+B7diOtoYjEtSWJVMEbJ7ZH72/TZIe73NwYwY7KFRMVefwxcJE29G+my4vaPmttf2Lbnri8pD6Jw=="],
+
+    "syncpack-darwin-x64": ["syncpack-darwin-x64@15.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-KX5+fcHzaGugppyPV3se8iKoFYE5Jde3ZxN80dJKNejluP29rGmOQ1JNaVjy40nZInPNLKQ8LS0TMRtxIgh8ew=="],
+
+    "syncpack-linux-arm64": ["syncpack-linux-arm64@15.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-5saJ4LnizTppqVLt49MKagTixDpuR+5MFweGCkoEAm4SikLqNfzkiEnHqVsjY3+BkCVtXf6DcR1OX6hwswNJ0A=="],
+
+    "syncpack-linux-arm64-musl": ["syncpack-linux-arm64-musl@15.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-YslfJ1UndTwL000p0JTP/r8uwXJ4LfYeFBqAfRhLuWoJz8CO+yWyUl4VNdFNitSR1OOB/J7gc4q3jOsxh7kTOg=="],
+
+    "syncpack-linux-x64": ["syncpack-linux-x64@15.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bk8keNTteQxXpKDc+Y3r3fE7IZn4cU61gq7ka4gPcBNvvMHOk8Pg71/qQEwN3zBtzAj6yF1Fyzb0NYK9Wo6EPQ=="],
+
+    "syncpack-linux-x64-musl": ["syncpack-linux-x64-musl@15.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/mnWa3FmzJRsDLuqx6rzQIawV5ly1MFyUPxcZlaLX3FbxBryrVXJZZXGd0yJ9UTEKgE5UfRRQlS+ayeXvJbNew=="],
+
+    "syncpack-windows-arm64": ["syncpack-windows-arm64@15.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-GIKQtpNl1Ox2gwBDlEXgL1rneMwUMG0E3eB+EjDKdh4kOJtO0DYduTgg10dmFk/i1ynKGvFtgvhN3VZAr75jgA=="],
+
+    "syncpack-windows-x64": ["syncpack-windows-x64@15.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4Kl7gCFzaEF7IoHa3vcEHRPx1um8pnzEqidRyQProIJBROG4srgkyQkmwJUXbWzWJhAq2Ic0vtDUvzIXF2U/Dg=="],
 
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[install]
+# Supply-chain hardening: refuse npm package versions published more recently
+# than this threshold (in seconds). 604800 = 7 days. This is install-time
+# defense-in-depth; the primary one-week gate is the Dependabot cooldown
+# (.github/dependabot.yml), which holds update PRs until a version is at least
+# seven days old — long enough for most malicious releases to be yanked.
+minimumReleaseAge = 604800

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "lint:deps": "syncpack lint",
+    "fix:deps": "syncpack fix",
     "dev:website": "vitepress dev website",
     "build:website": "vitepress build website",
     "preview:website": "vitepress preview website",
-    "prepublishOnly": "bun run typecheck && bun run test && bun run build"
+    "prepublishOnly": "bun run lint:deps && bun run typecheck && bun run test && bun run build"
   },
   "keywords": [
     "workflow",
@@ -75,14 +77,15 @@
     }
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
-    "@vitest/coverage-v8": "^4.0.18",
-    "better-sqlite3": "^12.6.2",
-    "tsdown": "^0.21.0",
-    "typescript": "^5.9.3",
-    "vitepress": "^1.6.4",
-    "vitest": "^4.0.18",
-    "zod": "^4.3.6"
+    "@types/better-sqlite3": "7.6.13",
+    "@vitest/coverage-v8": "4.0.18",
+    "better-sqlite3": "12.6.2",
+    "syncpack": "15.3.1",
+    "tsdown": "0.21.2",
+    "typescript": "5.9.3",
+    "vitepress": "1.6.4",
+    "vitest": "4.0.18",
+    "zod": "4.3.6"
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0"


### PR DESCRIPTION
Hardens the supply chain ahead of the next release, mirroring the setup in [bonsai-js](https://github.com/danfry1/bonsai-js).

## Install-time defense
- **`bunfig.toml`**: `minimumReleaseAge = 604800` — `bun install` refuses any npm version published in the last 7 days.
- **Dependabot cooldown** (7 days, all bump types) — the primary gate; holds update PRs until a version has aged enough to be yanked if malicious.
- **Dependabot ecosystem `npm` → `bun`** — matches `bun.lock` (the `npm` ecosystem wasn't updating it).

## Pinned dependencies (syncpack)
- All **devDependencies pinned to exact versions** (the real attack surface); added `syncpack@15.3.1`.
- Runtime (`@standard-schema/spec`) and peer (`better-sqlite3 >=9.0.0`) deps **kept as ranges** so consumers can dedupe — the lockfile still pins them in CI.
- `.syncpackrc.json` enforces this; `syncpack lint` runs in CI and `prepublishOnly`.

## Staged publishing
- `npm publish` → **`npm stage publish`**: a tag push *stages* the version; it is **not installable** until a maintainer approves it with a 2FA challenge (`npm stage approve <id>`). Provenance is auto-generated via OIDC.
- Installs `npm@11.15.0` (required for `npm stage`); `npm pack --ignore-scripts`.

## Workflows
- All `bun install` → `--frozen-lockfile`; added a pinned-deps lint gate to CI.
- Unified the `setup-node` SHA pin across workflows (all actions remain SHA-pinned).

## ⚠️ Before releasing
1. **Trusted publishing (OIDC) must be configured on npmjs.com for `reflow-ts`** — same as bonsai. The workflow already has `id-token: write`.
2. Releases are now **two-step**: pushing a `v*` tag stages the version; approve it with 2FA to make it installable.

Verified locally: `syncpack lint`, `typecheck`, and `build` all pass; the new release-age gate does not block install.