### PR TITLE
fix: use git+ prefix for repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/danfry1/reflow-ts.git"
+    "url": "git+https://github.com/danfry1/reflow-ts.git"
   },
   "homepage": "https://danfry1.github.io/reflow-ts/",
   "bugs": "https://github.com/danfry1/reflow-ts/issues",


### PR DESCRIPTION
Silences the `npm warn stage "repository.url" was normalized` warning seen during the 0.5.0 staged publish. npm normalizes the repository URL to the `git+https://` form on publish; this just stores the canonical value so the warning no longer appears on future releases.