### PR TITLE
feat: conditional steps via when predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Conditional steps** — `.step(name, { when, handler })` accepts an optional `when` predicate receiving `{ input, prev, steps }`. When it returns `false` the step is skipped: `prev` passes through unchanged to the next step, the step is recorded with the new `skipped` status, and a `stepSkipped` event fires (with a matching `onStepSkipped` hook). The decision is evaluated once and persisted, so it is never recomputed on crash-recovery replay; a throwing predicate fails the run at that step. `when` may be synchronous or `async`. New exported types: `StepCondition`, `StepConditionContext`. ([#21](https://github.com/danfry1/reflow-ts/issues/21))
+
+### Changed
+
+- `StepStatus` has a new value, `skipped`, and `EngineEvent` / `EngineHooks` gain the additive `stepSkipped` / `onStepSkipped` variant. Existing code is unaffected.
+
 ## 0.5.0 — 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Conditional steps** — `.step(name, { when, handler })` accepts an optional `when` predicate receiving `{ input, prev, steps }`. When it returns `false` the step is skipped: `prev` passes through unchanged to the next step, the step is recorded with the new `skipped` status, and a `stepSkipped` event fires (with a matching `onStepSkipped` hook). The decision is evaluated once and persisted, so it is never recomputed on crash-recovery replay; a throwing predicate fails the run at that step. `when` may be synchronous or `async`. New exported types: `StepCondition`, `StepConditionContext`. ([#21](https://github.com/danfry1/reflow-ts/issues/21))
+- **Conditional steps** — `.step(name, { when, handler })` accepts an optional `when` predicate receiving `{ input, prev, steps }`. When it returns `false` the step is skipped: `prev` passes through unchanged to the next step, the step is recorded with the new `skipped` status, and a `stepSkipped` event fires (with a matching `onStepSkipped` hook). The decision is evaluated once and persisted, so it is never recomputed on crash-recovery replay; a throwing predicate fails the run at that step. `when` may be synchronous or `async`, and is supported on sequential `.step()` only — passing it to a `.parallel()` branch throws `ConfigError`. New exported types: `StepCondition`, `StepConditionContext`. ([#21](https://github.com/danfry1/reflow-ts/issues/21))
 
 ### Changed
 

--- a/src/core/__tests__/conditional.test.ts
+++ b/src/core/__tests__/conditional.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
-import { createWorkflow, createEngine } from '../../index'
+import { createWorkflow, createEngine, ConfigError } from '../../index'
 import { MemoryStorage } from '../../storage/memory'
 
 describe('conditional steps (when)', () => {
@@ -171,5 +171,39 @@ describe('conditional steps (when)', () => {
 
     expect((await engine.getRunStatus(run.id))?.run.status).toBe('failed')
     expect(onFailure).toHaveBeenCalledWith({ message: 'flag service down', stepName: 'b' })
+  })
+
+  it('rejects `when` on a parallel branch', () => {
+    expect(() =>
+      createWorkflow({ name: 'cond-parallel', input: z.object({}) }).parallel({
+        a: { when: () => false, handler: async () => ({ ok: true }) },
+        b: async () => ({ ok: true }),
+      }),
+    ).toThrow(ConfigError)
+  })
+
+  it('does not emit stepStart for a skipped step', async () => {
+    const wf = createWorkflow({ name: 'no-start', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+      .step('b', { when: () => false, handler: async () => ({ ok: true }) })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const starts: string[] = []
+    const stream = engine.stream()
+    const collector = (async () => {
+      for await (const event of stream) {
+        if (event.type === 'stepStart') starts.push(event.stepName)
+        if (event.type === 'runComplete') break
+      }
+    })()
+
+    await engine.enqueue('no-start', {})
+    await engine.tick()
+    await collector
+
+    // 'b' was skipped — only 'a' started.
+    expect(starts).toEqual(['a'])
   })
 })

--- a/src/core/__tests__/conditional.test.ts
+++ b/src/core/__tests__/conditional.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { createWorkflow, createEngine } from '../../index'
+import { MemoryStorage } from '../../storage/memory'
+
+describe('conditional steps (when)', () => {
+  it('skips the step and passes prev through unchanged when the condition is false', async () => {
+    const upgrade = vi.fn()
+
+    const wf = createWorkflow({
+      name: 'cond',
+      input: z.object({ premium: z.boolean() }),
+    })
+      .step('base', async () => ({ tier: 'base' }))
+      .step('upgrade', {
+        when: ({ input }) => input.premium,
+        handler: async () => {
+          upgrade()
+          return { tier: 'premium' }
+        },
+      })
+      .step('finalize', async ({ prev }) => ({ finalTier: prev.tier }))
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const run = await engine.enqueue('cond', { premium: false })
+    await engine.tick()
+
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('completed')
+    // `upgrade` never ran...
+    expect(upgrade).not.toHaveBeenCalled()
+    // ...and `finalize` saw `base`'s output as prev.
+    expect(info?.steps.find((s) => s.name === 'finalize')?.output).toEqual({ finalTier: 'base' })
+    // The skip is persisted.
+    expect(info?.steps.find((s) => s.name === 'upgrade')?.status).toBe('skipped')
+  })
+
+  it('runs the step when the condition is true', async () => {
+    const wf = createWorkflow({
+      name: 'cond-true',
+      input: z.object({ premium: z.boolean() }),
+    })
+      .step('base', async () => ({ tier: 'base' }))
+      .step('upgrade', {
+        when: ({ input }) => input.premium,
+        handler: async () => ({ tier: 'premium' }),
+      })
+      .step('finalize', async ({ prev }) => ({ finalTier: prev.tier }))
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const run = await engine.enqueue('cond-true', { premium: true })
+    await engine.tick()
+
+    const info = await engine.getRunStatus(run.id)
+    expect(info?.steps.find((s) => s.name === 'upgrade')?.status).toBe('completed')
+    expect(info?.steps.find((s) => s.name === 'finalize')?.output).toEqual({ finalTier: 'premium' })
+  })
+
+  it('supports an async condition', async () => {
+    const wf = createWorkflow({
+      name: 'async-cond',
+      input: z.object({ flag: z.boolean() }),
+    })
+      .step('a', async () => ({ n: 1 }))
+      .step('b', {
+        when: async ({ input }) => {
+          await Promise.resolve()
+          return input.flag
+        },
+        handler: async () => ({ n: 2 }),
+      })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const run = await engine.enqueue('async-cond', { flag: false })
+    await engine.tick()
+
+    expect((await engine.getRunStatus(run.id))?.steps.find((s) => s.name === 'b')?.status).toBe('skipped')
+  })
+
+  it('leaves a skipped step undefined in the steps map for later steps', async () => {
+    const wf = createWorkflow({
+      name: 'steps-map',
+      input: z.object({}),
+    })
+      .step('a', async () => ({ v: 1 }))
+      .step('maybe', { when: () => false, handler: async () => ({ v: 2 }) })
+      .step('c', async ({ steps }) => ({ seenMaybe: steps.maybe === undefined }))
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const run = await engine.enqueue('steps-map', {})
+    await engine.tick()
+
+    expect((await engine.getRunStatus(run.id))?.steps.find((s) => s.name === 'c')?.output).toEqual({
+      seenMaybe: true,
+    })
+  })
+
+  it('emits stepSkipped to hooks and streams', async () => {
+    const onStepSkipped = vi.fn()
+
+    const wf = createWorkflow({ name: 'evt', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+      .step('b', { when: () => false, handler: async () => ({ ok: true }) })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf], hooks: { onStepSkipped } })
+
+    const seen: string[] = []
+    const stream = engine.stream()
+    const collector = (async () => {
+      for await (const event of stream) {
+        if (event.type === 'stepSkipped') seen.push(event.stepName)
+        if (event.type === 'runComplete') break
+      }
+    })()
+
+    await engine.enqueue('evt', {})
+    await engine.tick()
+    await collector
+
+    expect(onStepSkipped).toHaveBeenCalledTimes(1)
+    expect(onStepSkipped.mock.calls[0][0]).toMatchObject({ type: 'stepSkipped', stepName: 'b', workflow: 'evt' })
+    expect(seen).toEqual(['b'])
+  })
+
+  it('evaluates the condition exactly once — the decision is persisted, not recomputed on replay', async () => {
+    const when = vi.fn(() => false)
+
+    const wf = createWorkflow({ name: 'once', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+      .step('b', { when, handler: async () => ({ ok: true }) })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const run = await engine.enqueue('once', {})
+    await engine.tick()
+    // A second tick finds no pending work; the completed run is never re-evaluated.
+    await engine.tick()
+
+    expect(when).toHaveBeenCalledTimes(1)
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('completed')
+  })
+
+  it('fails the run at the step when the condition throws', async () => {
+    const onFailure = vi.fn()
+
+    const wf = createWorkflow({ name: 'throws', input: z.object({}) })
+      .step('a', async () => ({ ok: true }))
+      .step('b', {
+        when: () => {
+          throw new Error('flag service down')
+        },
+        handler: async () => ({ ok: true }),
+      })
+      .onFailure(async ({ error, stepName }) => onFailure({ message: error.message, stepName }))
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+
+    const run = await engine.enqueue('throws', {})
+    await engine.tick()
+
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('failed')
+    expect(onFailure).toHaveBeenCalledWith({ message: 'flag service down', stepName: 'b' })
+  })
+})

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -35,6 +35,7 @@ import type { AnyWorkflow, StepDefinition, WorkflowInputMap } from './workflow'
 export type EngineEvent =
   | { readonly type: 'runStart'; readonly runId: string; readonly workflow: string }
   | { readonly type: 'stepStart'; readonly runId: string; readonly workflow: string; readonly stepName: string }
+  | { readonly type: 'stepSkipped'; readonly runId: string; readonly workflow: string; readonly stepName: string }
   | {
       readonly type: 'stepComplete'
       readonly runId: string
@@ -59,6 +60,8 @@ export type EngineEventOf<T extends EngineEvent['type']> = Extract<EngineEvent, 
 export interface EngineHooks {
   onRunStart?: (event: EngineEventOf<'runStart'>) => void
   onStepStart?: (event: EngineEventOf<'stepStart'>) => void
+  /** Called when a step's `when` predicate returns false and the step is skipped. */
+  onStepSkipped?: (event: EngineEventOf<'stepSkipped'>) => void
   onStepComplete?: (event: EngineEventOf<'stepComplete'>) => void
   onRunComplete?: (event: EngineEventOf<'runComplete'>) => void
   onRunFailed?: (event: EngineEventOf<'runFailed'>) => void
@@ -310,6 +313,8 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
         return hooks?.onRunStart?.({ ...event })
       case 'stepStart':
         return hooks?.onStepStart?.({ ...event })
+      case 'stepSkipped':
+        return hooks?.onStepSkipped?.({ ...event })
       case 'stepComplete':
         return hooks?.onStepComplete?.({
           ...event,
@@ -416,10 +421,46 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
             stepsAccumulator[stepDef.name] = structuredClone(existing.output)
             continue
           }
+          if (existing?.status === 'skipped') {
+            // Skipped on a previous execution — leave `prev` untouched (the
+            // last real output passes through) and move to the next unit.
+            continue
+          }
 
           const frozenSteps = snapshotSteps(stepsAccumulator)
 
           try {
+            if (
+              stepDef.when &&
+              !(await stepDef.when({ input: run.input, prev, steps: frozenSteps }))
+            ) {
+              // Condition is false — persist a skip so it is not re-evaluated on
+              // replay, leave `prev` unchanged, and continue to the next unit.
+              const now = Date.now()
+              const saved = await storage.saveStepResult({
+                id: randomUUID(),
+                runId: run.id,
+                name: stepDef.name,
+                status: 'skipped',
+                output: null,
+                error: null,
+                attempts: 0,
+                createdAt: now,
+                updatedAt: now,
+              }, run.leaseId)
+
+              if (!saved) {
+                throw new LeaseExpiredError(run.id)
+              }
+
+              await emit(
+                { type: 'stepSkipped', runId: run.id, workflow: run.workflow, stepName: stepDef.name },
+                observerSignal,
+              )
+
+              continue
+            }
+
             await emit(
               { type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: stepDef.name },
               observerSignal,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,7 +2,7 @@
 export type RunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
 
 /** Lifecycle state of a single step within a run. */
-export type StepStatus = 'pending' | 'running' | 'completed' | 'completed-early' | 'failed'
+export type StepStatus = 'pending' | 'running' | 'completed' | 'completed-early' | 'skipped' | 'failed'
 
 /** Primitive values that can be persisted to storage. */
 export type PersistedPrimitive = string | number | boolean | null | undefined | Date

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -20,12 +20,38 @@ export interface StepContext<
   steps: TStepsSoFar
 }
 
+/**
+ * Context passed to a step's `when` predicate. A subset of {@link StepContext}:
+ * the inputs available to decide whether the step should run, with no `signal`
+ * or `complete` (the predicate makes a routing decision, it does not execute).
+ */
+export interface StepConditionContext<
+  TInput extends PersistedValue,
+  TPrev extends PersistedValue,
+  TStepsSoFar extends Record<string, PersistedValue> = Record<string, PersistedValue>,
+> {
+  /** The validated workflow input. */
+  input: TInput
+  /** The output of the previous step. */
+  prev: TPrev
+  /** Results of all previously completed steps, keyed by step name. */
+  steps: TStepsSoFar
+}
+
+/** A predicate deciding whether a step runs. Evaluated once; the decision is persisted and not re-evaluated on replay. */
+export type StepCondition<
+  TInput extends PersistedValue,
+  TPrev extends PersistedValue,
+  TStepsSoFar extends Record<string, PersistedValue> = Record<string, PersistedValue>,
+> = (ctx: StepConditionContext<TInput, TPrev, TStepsSoFar>) => boolean | Promise<boolean>
+
 /** Internal representation of a step used by the engine. */
 export interface StepDefinition {
   name: string
   handler: (ctx: StepContext<PersistedValue, PersistedValue, Record<string, PersistedValue>>) => Promise<PersistedValue | void>
   retry?: RetryConfig
   timeoutMs?: number
+  when?: (ctx: StepConditionContext<PersistedValue, PersistedValue, Record<string, PersistedValue>>) => boolean | Promise<boolean>
 }
 
 /** A single execution unit: either a sequential step or a parallel group. */
@@ -43,6 +69,13 @@ export interface StepConfig<
   retry?: RetryConfig
   /** Timeout per attempt in milliseconds. Takes precedence over `retry.timeoutMs`. */
   timeoutMs?: number
+  /**
+   * Optional predicate deciding whether this step runs. Evaluated once with the
+   * current `input`, `prev`, and `steps`; when it returns `false` the step is
+   * skipped, `prev` passes through unchanged to the next step, and the skip is
+   * persisted so it is not re-evaluated on replay.
+   */
+  when?: StepCondition<TInput, TPrev, TStepsSoFar>
   handler: (ctx: StepContext<TInput, TPrev, TStepsSoFar>) => Promise<TOutput>
 }
 
@@ -216,12 +249,14 @@ function buildWorkflow<
       const handler = isConfig ? handlerOrConfig.handler : handlerOrConfig
       const retry = isConfig ? handlerOrConfig.retry : undefined
       const timeoutMs = isConfig ? handlerOrConfig.timeoutMs : undefined
+      const when = isConfig ? handlerOrConfig.when : undefined
 
       const newStep: StepDefinition = {
         name: stepName,
         handler: handler as unknown as StepDefinition['handler'],
         retry,
         timeoutMs,
+        when: when as unknown as StepDefinition['when'],
       }
       return buildWorkflow<
         TName,

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -74,6 +74,15 @@ export interface StepConfig<
    * current `input`, `prev`, and `steps`; when it returns `false` the step is
    * skipped, `prev` passes through unchanged to the next step, and the skip is
    * persisted so it is not re-evaluated on replay.
+   *
+   * Caveats:
+   * - A skipped step is **absent** from later steps' `steps` map (it reads as
+   *   `undefined` at runtime even though the type lists it). Read it through the
+   *   passed-through `prev` instead, or guard for `undefined`.
+   * - `when` is not passed the abort `signal`; a slow async predicate is not
+   *   interrupted by cancellation (the abort is observed once it resolves).
+   * - Supported on sequential `.step()` only — passing `when` to a `.parallel()`
+   *   branch throws `ConfigError`.
    */
   when?: StepCondition<TInput, TPrev, TStepsSoFar>
   handler: (ctx: StepContext<TInput, TPrev, TStepsSoFar>) => Promise<TOutput>
@@ -293,6 +302,14 @@ function buildWorkflow<
 
       const branchDefs: StepDefinition[] = branchEntries.map(([branchName, handlerOrConfig]) => {
         if (typeof handlerOrConfig === 'object' && handlerOrConfig !== null && 'handler' in handlerOrConfig) {
+          if ('when' in handlerOrConfig && handlerOrConfig.when !== undefined) {
+            // `when` skips a step by passing `prev` through to the next one;
+            // there is no well-defined passthrough for one branch of a
+            // concurrent group, so reject it rather than silently ignoring it.
+            throw new ConfigError(
+              `Conditional "when" is not supported on parallel branch "${branchName}" in workflow "${name}"`,
+            )
+          }
           return {
             name: branchName,
             handler: handlerOrConfig.handler as unknown as StepDefinition['handler'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export type {
   StepContext,
   StepDefinition,
   StepConfig,
+  StepCondition,
+  StepConditionContext,
   ParallelBranch,
   InferBranchOutput,
   FailureContext,

--- a/website/api/create-engine.md
+++ b/website/api/create-engine.md
@@ -30,6 +30,7 @@ All hooks are optional and receive an [`EngineEvent`](/api/events)-shaped payloa
 |---|---|
 | `onRunStart` | `{ runId, workflow }` |
 | `onStepStart` | `{ runId, workflow, stepName }` |
+| `onStepSkipped` | `{ runId, workflow, stepName }` |
 | `onStepComplete` | `{ runId, workflow, stepName, output, attempts }` |
 | `onRunComplete` | `{ runId, workflow, output }` |
 | `onRunFailed` | `{ runId, workflow, stepName, error }` |

--- a/website/api/events.md
+++ b/website/api/events.md
@@ -10,6 +10,7 @@ A discriminated union on `type`. Every variant carries `runId` and `workflow`.
 type EngineEvent =
   | { type: 'runStart';     runId: string; workflow: string }
   | { type: 'stepStart';    runId: string; workflow: string; stepName: string }
+  | { type: 'stepSkipped';  runId: string; workflow: string; stepName: string }
   | { type: 'stepComplete'; runId: string; workflow: string; stepName: string; output: PersistedValue; attempts: number }
   | { type: 'runComplete';  runId: string; workflow: string; output: PersistedValue }
   | { type: 'runFailed';    runId: string; workflow: string; stepName: string; error: Error }
@@ -19,6 +20,7 @@ type EngineEvent =
 |---|---|
 | `runStart` | A run begins executing (also on crash-recovery resume) |
 | `stepStart` | Before each step (or parallel branch) runs |
+| `stepSkipped` | A step's [`when`](/api/workflow) predicate returned false and the step was skipped |
 | `stepComplete` | After a step's result is persisted |
 | `runComplete` | A run finishes successfully; `output` is the final result |
 | `runFailed` | A run fails; `stepName` is the offending step, `error` the cause |

--- a/website/api/workflow.md
+++ b/website/api/workflow.md
@@ -35,7 +35,7 @@ Adds a sequential step. Accepts either a bare handler or a config object.
 
 **Conditional steps (`when`):**
 
-When `when` returns `false`, the step does not run: `prev` passes through unchanged to the next step, the step is recorded with status `skipped`, and a [`stepSkipped`](/api/events) event fires. The decision is evaluated once and persisted, so it is never recomputed on replay. A skipped step is `undefined` in the next step's `steps` map. If `when` throws, the run fails at that step (reaching `onFailure` / `onRunFailed`).
+When `when` returns `false`, the step does not run: `prev` passes through unchanged to the next step, the step is recorded with status `skipped`, and a [`stepSkipped`](/api/events) event fires. The decision is evaluated once and persisted, so it is never recomputed on replay. A skipped step is `undefined` in the next step's `steps` map (read it via `prev` instead). If `when` throws, the run fails at that step (reaching `onFailure` / `onRunFailed`). `when` is supported on sequential `.step()` only — passing it to a `.parallel()` branch throws [`ConfigError`](/api/errors).
 
 ```typescript
 .step('charge', async () => ({ tier: 'base' }))

--- a/website/api/workflow.md
+++ b/website/api/workflow.md
@@ -31,6 +31,20 @@ Adds a sequential step. Accepts either a bare handler or a config object.
 | `handler` | `(ctx) => Promise<T>` | Step handler. Receives the step context above. |
 | `retry` | `RetryConfig` | Optional retry configuration. |
 | `timeoutMs` | `number` | Optional timeout per attempt (ms). Takes precedence over `retry.timeoutMs`. |
+| `when` | `(ctx) => boolean \| Promise<boolean>` | Optional predicate. Receives `{ input, prev, steps }`. When it returns `false` the step is skipped (see below). |
+
+**Conditional steps (`when`):**
+
+When `when` returns `false`, the step does not run: `prev` passes through unchanged to the next step, the step is recorded with status `skipped`, and a [`stepSkipped`](/api/events) event fires. The decision is evaluated once and persisted, so it is never recomputed on replay. A skipped step is `undefined` in the next step's `steps` map. If `when` throws, the run fails at that step (reaching `onFailure` / `onRunFailed`).
+
+```typescript
+.step('charge', async () => ({ tier: 'base' }))
+.step('upgrade', {
+  when: ({ input }) => input.premium,   // only run for premium orders
+  handler: async () => ({ tier: 'premium' }),
+})
+.step('finalize', async ({ prev }) => prev.tier) // 'base' when upgrade was skipped
+```
 
 **`RetryConfig`:**
 

--- a/website/guide/hooks.md
+++ b/website/guide/hooks.md
@@ -35,6 +35,7 @@ Every hook receives an event carrying `runId` and `workflow`. The shapes mirror 
 |---|---|---|
 | `onRunStart` | A run begins executing (also on crash-recovery resume) | — |
 | `onStepStart` | Before each step runs | `stepName` |
+| `onStepSkipped` | A step's [`when`](/api/workflow) predicate returned false | `stepName` |
 | `onStepComplete` | After a step's result is persisted | `stepName`, `output`, `attempts` |
 | `onRunComplete` | A run finishes successfully | `output` (the run's final result) |
 | `onRunFailed` | A run fails | `stepName`, `error` |


### PR DESCRIPTION
## Summary

Adds conditional step execution via an optional `when` predicate on step config — resolving the long-standing request to skip a step while still passing the last result through to subsequent steps.

```typescript
.step('charge', async () => ({ tier: 'base' }))
.step('upgrade', {
  when: ({ input }) => input.premium,   // only run for premium orders
  handler: async () => ({ tier: 'premium' }),
})
.step('finalize', async ({ prev }) => prev.tier) // 'base' when upgrade was skipped
```

## Behaviour

- `when` receives `{ input, prev, steps }` and may be synchronous or `async`.
- When it returns `false`: the step does not run, `prev` **passes through unchanged** to the next step, the step is recorded with the new `skipped` status, and a `stepSkipped` event fires (with a matching `onStepSkipped` hook).
- The decision is evaluated **once and persisted**, so it is never recomputed on crash-recovery replay.
- A skipped step is `undefined` in the next step's `steps` map.
- If `when` throws, the run fails at that step (reaching `onFailure` / `onRunFailed`).
- `when` is supported on sequential `.step()` only, not on parallel branches.

## API surface

- `StepConfig` gains `when?`. New exported types `StepCondition` and `StepConditionContext`.
- `StepStatus` gains `skipped`; `EngineEvent` / `EngineHooks` gain the additive `stepSkipped` / `onStepSkipped`.

All changes are additive — existing code type-checks and runs unchanged.

## Tests

New `conditional.test.ts` (7 cases): skip + prev passthrough, run-when-true, async predicate, `steps`-map behaviour, event/hook emission, evaluate-once-on-replay, and throwing-predicate failure. 367 tests pass; typecheck, build, and `lint:deps` all green.

Closes #21.
