### PR TITLE
feat: durable sleep via .sleep(name, duration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             createRun: async () => { throw new Error('not used') },
             claimNextRun: async () => null,
             heartbeatRun: async () => true,
+            sleepRun: async () => true,
             getRun: async () => null,
             getStepResults: async () => [],
             saveStepResult: async () => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `StorageAdapter` gains `sleepRun(runId, leaseId, wakeAt)`, and `claimNextRun` now also reclaims `sleeping` runs whose wake time has passed. Both are implemented across all built-in adapters; the SQLite adapters add a `wake_at` column with an automatic, backward-compatible migration for existing databases. Custom adapters must implement `sleepRun` and wake due `sleeping` runs in `claimNextRun`.
 - `RunStatus` gains `sleeping`; `StepStatus` gains `sleeping`.
+- The `node:sqlite` adapter now opens transactions with `BEGIN IMMEDIATE` so concurrent claims under WAL take the write lock up front instead of risking a non-retryable `SQLITE_BUSY_SNAPSHOT`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **Durable sleep** — `.sleep(name, duration)` pauses a workflow between steps for a duration that survives process exit, deploy, or crash. The run is persisted as `sleeping` with its lease released (so the process need not stay alive), and any engine instance reclaims and resumes it once the time elapses. `duration` is a number of milliseconds or a unit-suffixed string (`'500ms'`, `'30s'`, `'24h'`, `'7d'`). `prev` passes through unchanged, and the sleep is observable as a step (`sleeping` → `completed`).
+
+### Changed
+
+- `StorageAdapter` gains `sleepRun(runId, leaseId, wakeAt)`, and `claimNextRun` now also reclaims `sleeping` runs whose wake time has passed. Both are implemented across all built-in adapters; the SQLite adapters add a `wake_at` column with an automatic, backward-compatible migration for existing databases. Custom adapters must implement `sleepRun` and wake due `sleeping` runs in `claimNextRun`.
+- `RunStatus` gains `sleeping`; `StepStatus` gains `sleeping`.
+
 ### Fixed
 
 - **`reflow-ts/sqlite-bun` change detection** — `bun:sqlite` reports affected-row counts on the `run()` result, not on `Database.changes` (which is `undefined`). The adapter read the latter, so `heartbeatRun`, `updateRunStatus`, `updateClaimedRunStatus`, and the `claimNextRun` double-claim guard never reflected real row counts — heartbeats always reported the lease lost and the claim guard never engaged. The adapter now reads the count from the statement result. Adds a Bun-native smoke test (`bun run test:bun`) wired into CI so the Bun adapter — which the Node-based Vitest suite cannot load — has real coverage.

--- a/src/core/__tests__/duration.test.ts
+++ b/src/core/__tests__/duration.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { parseDuration } from '../duration'
+import { ConfigError } from '../errors'
+
+describe('parseDuration', () => {
+  it('passes through non-negative millisecond numbers', () => {
+    expect(parseDuration(0)).toBe(0)
+    expect(parseDuration(1500)).toBe(1500)
+  })
+
+  it('parses unit-suffixed strings', () => {
+    expect(parseDuration('500ms')).toBe(500)
+    expect(parseDuration('30s')).toBe(30_000)
+    expect(parseDuration('5m')).toBe(300_000)
+    expect(parseDuration('24h')).toBe(86_400_000)
+    expect(parseDuration('7d')).toBe(604_800_000)
+  })
+
+  it('tolerates whitespace and decimals', () => {
+    expect(parseDuration(' 2h ')).toBe(7_200_000)
+    expect(parseDuration('1.5s')).toBe(1500)
+  })
+
+  it('rejects negative or non-finite numbers', () => {
+    expect(() => parseDuration(-1)).toThrow(ConfigError)
+    expect(() => parseDuration(Number.POSITIVE_INFINITY)).toThrow(ConfigError)
+    expect(() => parseDuration(Number.NaN)).toThrow(ConfigError)
+  })
+
+  it('rejects unparseable strings', () => {
+    expect(() => parseDuration('soon')).toThrow(ConfigError)
+    expect(() => parseDuration('10')).toThrow(ConfigError)
+    expect(() => parseDuration('10 weeks')).toThrow(ConfigError)
+    expect(() => parseDuration('')).toThrow(ConfigError)
+  })
+})

--- a/src/core/__tests__/engine.test.ts
+++ b/src/core/__tests__/engine.test.ts
@@ -556,6 +556,7 @@ describe('Engine', () => {
 
           return delegate.heartbeatRun(runId, leaseId)
         },
+        sleepRun: (runId, leaseId, wakeAt) => delegate.sleepRun(runId, leaseId, wakeAt),
         getRun: (runId) => delegate.getRun(runId),
         getStepResults: (runId) => delegate.getStepResults(runId),
         saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),

--- a/src/core/__tests__/parallel-engine.test.ts
+++ b/src/core/__tests__/parallel-engine.test.ts
@@ -852,6 +852,7 @@ describe('Parallel engine execution', () => {
         claimNextRun: (workflowNames, staleBefore) =>
           delegate.claimNextRun(workflowNames, staleBefore),
         heartbeatRun: (runId, leaseId) => delegate.heartbeatRun(runId, leaseId),
+        sleepRun: (runId, leaseId, wakeAt) => delegate.sleepRun(runId, leaseId, wakeAt),
         getRun: (runId) => delegate.getRun(runId),
         getStepResults: (runId) => delegate.getStepResults(runId),
         saveStepResult: async (result, leaseId) => {
@@ -903,6 +904,7 @@ describe('Parallel engine execution', () => {
           if (heartbeatCalls === 1) throw new Error('heartbeat exploded')
           return delegate.heartbeatRun(runId, leaseId)
         },
+        sleepRun: (runId, leaseId, wakeAt) => delegate.sleepRun(runId, leaseId, wakeAt),
         getRun: (runId) => delegate.getRun(runId),
         getStepResults: (runId) => delegate.getStepResults(runId),
         saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),

--- a/src/core/__tests__/sleep.test.ts
+++ b/src/core/__tests__/sleep.test.ts
@@ -169,4 +169,28 @@ describe('durable sleep', () => {
         .sleep('x', '1s'),
     ).toThrow(DuplicateStepError)
   })
+
+  it('supports a sleep as the very first unit (prev stays undefined)', async () => {
+    let firstPrev: unknown = 'unset'
+
+    const wf = createWorkflow({ name: 'sleep-first', input: z.object({}) })
+      .sleep('warmup', '1h')
+      .step('first', async ({ prev }) => {
+        firstPrev = prev
+        return { ran: true }
+      })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+    const run = await engine.enqueue('sleep-first', {})
+
+    await engine.tick()
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('sleeping')
+
+    vi.setSystemTime(Date.now() + 3_600_001)
+    await engine.tick()
+
+    expect(firstPrev).toBeUndefined()
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('completed')
+  })
 })

--- a/src/core/__tests__/sleep.test.ts
+++ b/src/core/__tests__/sleep.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { z } from 'zod'
+import { createWorkflow, createEngine } from '../../index'
+import { DuplicateStepError } from '../errors'
+import { MemoryStorage } from '../../storage/memory'
+
+describe('durable sleep', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('suspends the run at the sleep and resumes once the time elapses', async () => {
+    const ran: string[] = []
+
+    const wf = createWorkflow({ name: 'sleeper', input: z.object({}) })
+      .step('a', async () => {
+        ran.push('a')
+        return { from: 'a' }
+      })
+      .sleep('cooldown', '1h')
+      .step('b', async ({ prev }) => {
+        ran.push('b')
+        return { prev }
+      })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+    const run = await engine.enqueue('sleeper', {})
+
+    // First tick runs `a`, hits the sleep, and suspends.
+    await engine.tick()
+    expect(ran).toEqual(['a'])
+    let info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('sleeping')
+    expect(info?.steps.find((s) => s.name === 'cooldown')?.status).toBe('sleeping')
+
+    // Before the wake time, the run is not claimable.
+    await engine.tick()
+    expect(ran).toEqual(['a'])
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('sleeping')
+
+    // Advance past the wake time; the next tick resumes and completes.
+    vi.setSystemTime(Date.now() + 3_600_001)
+    await engine.tick()
+
+    expect(ran).toEqual(['a', 'b'])
+    info = await engine.getRunStatus(run.id)
+    expect(info?.run.status).toBe('completed')
+    expect(info?.steps.find((s) => s.name === 'cooldown')?.status).toBe('completed')
+    // `prev` passed through the sleep unchanged.
+    expect(info?.steps.find((s) => s.name === 'b')?.output).toEqual({ prev: { from: 'a' } })
+  })
+
+  it('completes a zero-length sleep in a single tick without suspending', async () => {
+    const ran: string[] = []
+
+    const wf = createWorkflow({ name: 'instant', input: z.object({}) })
+      .step('a', async () => {
+        ran.push('a')
+        return undefined
+      })
+      .sleep('noop', 0)
+      .step('b', async () => {
+        ran.push('b')
+        return undefined
+      })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+    const run = await engine.enqueue('instant', {})
+
+    await engine.tick()
+
+    expect(ran).toEqual(['a', 'b'])
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('completed')
+  })
+
+  it('resumes a sleeping run on a different engine instance (crash recovery)', async () => {
+    const ran: string[] = []
+    const makeWf = () =>
+      createWorkflow({ name: 'durable', input: z.object({}) })
+        .step('a', async () => {
+          ran.push('a')
+          return { ok: true }
+        })
+        .sleep('wait', '2h')
+        .step('b', async () => {
+          ran.push('b')
+          return { done: true }
+        })
+
+    const storage = new MemoryStorage()
+
+    const engine1 = createEngine({ storage, workflows: [makeWf()] })
+    const run = await engine1.enqueue('durable', {})
+    await engine1.tick()
+    expect((await engine1.getRunStatus(run.id))?.run.status).toBe('sleeping')
+
+    // A fresh engine (simulated restart) reclaims and resumes once due.
+    vi.setSystemTime(Date.now() + 7_200_001)
+    const engine2 = createEngine({ storage, workflows: [makeWf()] })
+    await engine2.tick()
+
+    expect(ran).toEqual(['a', 'b'])
+    expect((await engine2.getRunStatus(run.id))?.run.status).toBe('completed')
+  })
+
+  it('does not re-run earlier steps when it resumes from a sleep', async () => {
+    const aCalls = vi.fn()
+
+    const wf = createWorkflow({ name: 'no-rerun', input: z.object({}) })
+      .step('a', async () => {
+        aCalls()
+        return { v: 1 }
+      })
+      .sleep('wait', '10m')
+      .step('b', async () => ({ v: 2 }))
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+    await engine.enqueue('no-rerun', {})
+
+    await engine.tick()
+    vi.setSystemTime(Date.now() + 600_001)
+    await engine.tick()
+
+    expect(aCalls).toHaveBeenCalledTimes(1)
+  })
+
+  it('can cancel a sleeping run', async () => {
+    const ran: string[] = []
+
+    const wf = createWorkflow({ name: 'cancellable', input: z.object({}) })
+      .step('a', async () => {
+        ran.push('a')
+        return undefined
+      })
+      .sleep('wait', '1h')
+      .step('b', async () => {
+        ran.push('b')
+        return undefined
+      })
+
+    const storage = new MemoryStorage()
+    const engine = createEngine({ storage, workflows: [wf] })
+    const run = await engine.enqueue('cancellable', {})
+
+    await engine.tick()
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('sleeping')
+
+    expect(await engine.cancel(run.id)).toBe(true)
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('cancelled')
+
+    // Even after the wake time, a cancelled run never resumes.
+    vi.setSystemTime(Date.now() + 3_600_001)
+    await engine.tick()
+    expect(ran).toEqual(['a'])
+    expect((await engine.getRunStatus(run.id))?.run.status).toBe('cancelled')
+  })
+
+  it('rejects a sleep whose name collides with another step', () => {
+    expect(() =>
+      createWorkflow({ name: 'dup', input: z.object({}) })
+        .step('x', async () => undefined)
+        .sleep('x', '1s'),
+    ).toThrow(DuplicateStepError)
+  })
+})

--- a/src/core/__tests__/stream.test.ts
+++ b/src/core/__tests__/stream.test.ts
@@ -57,6 +57,7 @@ function delaySecondClaim(
       return delegate.claimNextRun(workflowNames, staleBefore)
     },
     heartbeatRun: (runId, leaseId) => delegate.heartbeatRun(runId, leaseId),
+    sleepRun: (runId, leaseId, wakeAt) => delegate.sleepRun(runId, leaseId, wakeAt),
     getRun: (runId) => delegate.getRun(runId),
     getStepResults: (runId) => delegate.getStepResults(runId),
     saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),
@@ -256,6 +257,7 @@ describe('async hooks', () => {
         if (heartbeatCalls === 1) throw new Error('heartbeat failed')
         return delegate.heartbeatRun(runId, leaseId)
       },
+      sleepRun: (runId, leaseId, wakeAt) => delegate.sleepRun(runId, leaseId, wakeAt),
       getRun: (runId) => delegate.getRun(runId),
       getStepResults: (runId) => delegate.getStepResults(runId),
       saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),
@@ -628,6 +630,7 @@ describe('engine.stream()', () => {
       claimNextRun: (workflowNames, staleBefore) =>
         delegate.claimNextRun(workflowNames, staleBefore),
       heartbeatRun: async () => false,
+      sleepRun: (runId, leaseId, wakeAt) => delegate.sleepRun(runId, leaseId, wakeAt),
       getRun: (runId) => delegate.getRun(runId),
       getStepResults: (runId) => delegate.getStepResults(runId),
       saveStepResult: (result, leaseId) => delegate.saveStepResult(result, leaseId),

--- a/src/core/duration.ts
+++ b/src/core/duration.ts
@@ -1,0 +1,39 @@
+import { ConfigError } from './errors'
+
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+}
+
+const DURATION_PATTERN = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/
+
+/**
+ * Normalize a duration to milliseconds.
+ *
+ * Accepts a non-negative number of milliseconds, or a string with a single unit
+ * suffix: `ms`, `s`, `m`, `h`, or `d` (e.g. `'500ms'`, `'30s'`, `'24h'`, `'7d'`).
+ *
+ * @throws {ConfigError} if the value is negative, non-finite, or an unparseable string.
+ */
+export function parseDuration(value: number | string): number {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new ConfigError(`Invalid duration: ${value}ms must be a non-negative, finite number`)
+    }
+    return value
+  }
+
+  const match = DURATION_PATTERN.exec(value.trim())
+  if (!match) {
+    throw new ConfigError(
+      `Invalid duration string "${value}". Use a number of milliseconds or a value with a unit suffix, e.g. "500ms", "30s", "24h", "7d".`,
+    )
+  }
+
+  const amount = Number(match[1])
+  const unit = match[2]
+  return amount * UNIT_MS[unit]
+}

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -548,6 +548,16 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
             return
           }
         } else if (unit.kind === 'sleep') {
+          // Mirror the step branch: if the run was cancelled (or the engine
+          // stopped) on an await before this unit, bail before emitting a
+          // spurious stepStart or touching storage.
+          if (activeRun.runAbortController.signal.aborted) {
+            const latestRun = await storage.getRun(run.id)
+            if (!latestRun || latestRun.status === 'cancelled') {
+              return
+            }
+          }
+
           const existing = completedMap.get(unit.name)
           if (existing?.status === 'completed') {
             // Already slept on a previous execution — `prev` passes through.

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -547,6 +547,71 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
 
             return
           }
+        } else if (unit.kind === 'sleep') {
+          const existing = completedMap.get(unit.name)
+          if (existing?.status === 'completed') {
+            // Already slept on a previous execution — `prev` passes through.
+            continue
+          }
+
+          const resuming = existing?.status === 'sleeping'
+          const wakeAt = resuming ? Number(existing.output) : Date.now() + unit.durationMs
+          const stepId = existing?.id ?? randomUUID()
+          const createdAt = existing?.createdAt ?? Date.now()
+
+          if (!resuming) {
+            await emit(
+              { type: 'stepStart', runId: run.id, workflow: run.workflow, stepName: unit.name },
+              observerSignal,
+            )
+          }
+
+          if (Date.now() >= wakeAt) {
+            // The sleep has elapsed (or was zero-length) — record it and continue.
+            const now = Date.now()
+            const saved = await storage.saveStepResult({
+              id: stepId,
+              runId: run.id,
+              name: unit.name,
+              status: 'completed',
+              output: null,
+              error: null,
+              attempts: 0,
+              createdAt,
+              updatedAt: now,
+            }, run.leaseId)
+            if (!saved) {
+              throw new LeaseExpiredError(run.id)
+            }
+            await emit(
+              { type: 'stepComplete', runId: run.id, workflow: run.workflow, stepName: unit.name, output: null, attempts: 0 },
+              observerSignal,
+            )
+            continue
+          }
+
+          // Not yet time: persist the wake target and durably suspend the run.
+          const now = Date.now()
+          const saved = await storage.saveStepResult({
+            id: stepId,
+            runId: run.id,
+            name: unit.name,
+            status: 'sleeping',
+            output: wakeAt,
+            error: null,
+            attempts: 0,
+            createdAt,
+            updatedAt: now,
+          }, run.leaseId)
+          if (!saved) {
+            throw new LeaseExpiredError(run.id)
+          }
+
+          const slept = await storage.sleepRun(run.id, run.leaseId, wakeAt)
+          if (!slept) {
+            throw new LeaseExpiredError(run.id)
+          }
+          return
         } else {
           const result = await executeParallelGroup(run, activeRun, unit.branches, prev, stepsAccumulator, completedMap)
           if (result.kind === 'skipped-cancelled') {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,8 +1,8 @@
 /** Lifecycle state of a workflow run. */
-export type RunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+export type RunStatus = 'pending' | 'running' | 'sleeping' | 'completed' | 'failed' | 'cancelled'
 
 /** Lifecycle state of a single step within a run. */
-export type StepStatus = 'pending' | 'running' | 'completed' | 'completed-early' | 'failed'
+export type StepStatus = 'pending' | 'running' | 'completed' | 'completed-early' | 'sleeping' | 'failed'
 
 /** Primitive values that can be persisted to storage. */
 export type PersistedPrimitive = string | number | boolean | null | undefined | Date
@@ -81,10 +81,20 @@ export interface StorageAdapter {
   initialize(): Promise<void>
   /** Persist a new run. Must handle idempotency key conflicts. */
   createRun(run: WorkflowRun): Promise<CreateRunResult>
-  /** Atomically claim the next pending (or stale) run for execution. */
+  /**
+   * Atomically claim the next runnable run for execution: a `pending` run, a
+   * stale `running` run (older than `staleBefore`), or a `sleeping` run whose
+   * wake time has passed.
+   */
   claimNextRun(workflowNames: readonly string[], staleBefore?: number): Promise<ClaimedRun | null>
   /** Renew the lease on a running run. Returns false if the lease was lost. */
   heartbeatRun(runId: string, leaseId: string): Promise<boolean>
+  /**
+   * Suspend a running run until `wakeAt` (epoch ms), releasing its lease so it
+   * can be reclaimed by `claimNextRun` once that time passes. Only succeeds if
+   * the caller still holds the lease; returns false otherwise.
+   */
+  sleepRun(runId: string, leaseId: string, wakeAt: number): Promise<boolean>
   /** Fetch a run by ID, or null if not found. */
   getRun(runId: string): Promise<WorkflowRun | null>
   /** Fetch all step results for a run, ordered by creation time. */

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -120,6 +120,11 @@ export interface Workflow<
    *
    * `duration` is a number of milliseconds or a string with a unit suffix
    * (`'500ms'`, `'30s'`, `'24h'`, `'7d'`). `name` must be unique within the workflow.
+   *
+   * The sleep emits `stepStart` when it begins and `stepComplete` when it
+   * elapses. If the run resumes on a *different* engine instance after
+   * suspending, that instance emits only `stepComplete` — `stepStart` was
+   * emitted by the instance that began the sleep.
    */
   sleep(name: string, duration: number | string): Workflow<TName, TInput, TPrev, TSteps>
 

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -1,4 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
+import { parseDuration } from './duration'
 import { ConfigError, DuplicateStepError, ValidationError } from './errors'
 import type { PersistedValue, RetryConfig } from './types'
 
@@ -28,10 +29,11 @@ export interface StepDefinition {
   timeoutMs?: number
 }
 
-/** A single execution unit: either a sequential step or a parallel group. */
+/** A single execution unit: a sequential step, a parallel group, or a durable sleep. */
 export type ExecutionUnit =
   | { readonly kind: 'step'; readonly definition: StepDefinition }
   | { readonly kind: 'parallel'; readonly branches: readonly StepDefinition[] }
+  | { readonly kind: 'sleep'; readonly name: string; readonly durationMs: number }
 
 /** Configuration object form for `.step()` when you need retry or timeout options. */
 export interface StepConfig<
@@ -110,6 +112,17 @@ export interface Workflow<
     TSteps & { [K in keyof TBranches & string]: NormalizeOutput<InferBranchOutput<TBranches[K]>> }
   >
 
+  /**
+   * Durably pause the workflow for `duration` before continuing. The run is
+   * persisted as `sleeping` and its lease released, so the process can exit (or
+   * crash) during the wait — another engine reclaims and resumes it once the
+   * time elapses. `prev` passes through unchanged to the next step.
+   *
+   * `duration` is a number of milliseconds or a string with a unit suffix
+   * (`'500ms'`, `'30s'`, `'24h'`, `'7d'`). `name` must be unique within the workflow.
+   */
+  sleep(name: string, duration: number | string): Workflow<TName, TInput, TPrev, TSteps>
+
   onFailure(
     handler: (ctx: FailureContext<TInput>) => Promise<void>,
   ): Workflow<TName, TInput, TPrev, TSteps>
@@ -171,6 +184,8 @@ function getAllStepNames(units: readonly ExecutionUnit[]): Set<string> {
   for (const unit of units) {
     if (unit.kind === 'step') {
       names.add(unit.definition.name)
+    } else if (unit.kind === 'sleep') {
+      names.add(unit.name)
     } else {
       for (const branch of unit.branches) {
         names.add(branch.name)
@@ -282,6 +297,21 @@ function buildWorkflow<
         name,
         inputSchema,
         [...executionUnits, { kind: 'parallel', branches: branchDefs }],
+        failureHandler,
+      )
+    },
+
+    sleep(sleepName: string, duration: number | string): Workflow<TName, TInput, TPrev, TSteps> {
+      if (getAllStepNames(executionUnits).has(sleepName)) {
+        throw new DuplicateStepError(name, sleepName)
+      }
+
+      const durationMs = parseDuration(duration)
+
+      return buildWorkflow<TName, TInput, TPrev, TSteps>(
+        name,
+        inputSchema,
+        [...executionUnits, { kind: 'sleep', name: sleepName, durationMs }],
         failureHandler,
       )
     },

--- a/src/storage/__tests__/memory.test.ts
+++ b/src/storage/__tests__/memory.test.ts
@@ -267,4 +267,29 @@ describe('MemoryStorage', () => {
       expect(await storage.updateClaimedRunStatus('run_1', claimed.leaseId, 'completed')).toBe(true)
     })
   })
+
+  describe('sleepRun / wake', () => {
+    it('suspends a claimed run; a non-matching lease cannot', async () => {
+      await storage.createRun(makeRun({ id: 'run_1' }))
+      const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+      expect(await storage.sleepRun('run_1', 'wrong-lease', Date.now() + 60_000)).toBe(false)
+      expect(await storage.sleepRun('run_1', claimed.leaseId, Date.now() + 60_000)).toBe(true)
+      expect(expectPresent(await storage.getRun('run_1')).status).toBe('sleeping')
+
+      // Not yet due — not claimable.
+      expect(await storage.claimNextRun(['test'])).toBeNull()
+    })
+
+    it('reclaims a sleeping run after its wake time with a fresh lease', async () => {
+      await storage.createRun(makeRun({ id: 'run_1' }))
+      const claimed = expectPresent(await storage.claimNextRun(['test']))
+      expect(await storage.sleepRun('run_1', claimed.leaseId, Date.now() - 1)).toBe(true)
+
+      const woken = expectPresent(await storage.claimNextRun(['test']))
+      expect(woken.id).toBe('run_1')
+      expect(woken.status).toBe('running')
+      expect(woken.leaseId).not.toBe(claimed.leaseId)
+    })
+  })
 })

--- a/src/storage/__tests__/sqlite-node-builtin.test.ts
+++ b/src/storage/__tests__/sqlite-node-builtin.test.ts
@@ -201,4 +201,26 @@ describe.skipIf(!nodeSqliteAvailable)('SQLiteStorage (node:sqlite)', () => {
     const run = expectPresent(await storage.getRun('run_1'))
     expect(run.status).toBe('completed')
   })
+
+  it('sleepRun suspends a run and rejects a non-matching lease', async () => {
+    await storage.createRun(makeRun({ id: 'run_1' }))
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+    expect(await storage.sleepRun('run_1', 'wrong', Date.now() + 60_000)).toBe(false)
+    expect(await storage.sleepRun('run_1', claimed.leaseId, Date.now() + 60_000)).toBe(true)
+    expect(expectPresent(await storage.getRun('run_1')).status).toBe('sleeping')
+
+    expect(await storage.claimNextRun(['test'])).toBeNull()
+  })
+
+  it('claimNextRun reclaims a sleeping run after its wake time', async () => {
+    await storage.createRun(makeRun({ id: 'run_1' }))
+    const claimed = expectPresent(await storage.claimNextRun(['test']))
+    expect(await storage.sleepRun('run_1', claimed.leaseId, Date.now() - 1)).toBe(true)
+
+    const woken = expectPresent(await storage.claimNextRun(['test']))
+    expect(woken.id).toBe('run_1')
+    expect(woken.status).toBe('running')
+    expect(woken.leaseId).not.toBe(claimed.leaseId)
+  })
 })

--- a/src/storage/__tests__/sqlite.test.ts
+++ b/src/storage/__tests__/sqlite.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import Database from 'better-sqlite3'
 import { SQLiteStorage } from '../sqlite-node'
 import { unlinkSync, existsSync } from 'node:fs'
 import type { WorkflowRun, StepResult } from '../../core/types'
@@ -459,6 +460,54 @@ describe('SQLiteStorage', () => {
 
       storage = new SQLiteStorage(DB_PATH)
       await storage.initialize()
+    })
+  })
+
+  describe('wake_at migration', () => {
+    it('adds wake_at to a pre-existing database that lacks it, then sleeps/wakes', async () => {
+      // Close the beforeEach storage and recreate the DB with the *old* schema
+      // (no wake_at column), as a database created before durable sleep would be.
+      storage.close()
+      if (existsSync(DB_PATH)) unlinkSync(DB_PATH)
+
+      const legacy = new Database(DB_PATH)
+      legacy.exec(`
+        CREATE TABLE workflow_runs (
+          id TEXT PRIMARY KEY, workflow TEXT NOT NULL, input TEXT NOT NULL,
+          idempotency_key TEXT, lease_id TEXT, status TEXT NOT NULL,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE workflow_steps (
+          id TEXT PRIMARY KEY, run_id TEXT NOT NULL, name TEXT NOT NULL,
+          status TEXT NOT NULL, output TEXT, error TEXT, attempts INTEGER DEFAULT 0,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+      `)
+      legacy.prepare(
+        `INSERT INTO workflow_runs (id, workflow, input, idempotency_key, lease_id, status, created_at, updated_at)
+         VALUES ('legacy', 'test', '{}', NULL, NULL, 'pending', 1, 1)`,
+      ).run()
+      legacy.close()
+
+      // initialize() must migrate the column in without dropping the existing row.
+      storage = new SQLiteStorage(DB_PATH)
+      await storage.initialize()
+
+      const claimed = expectPresent(await storage.claimNextRun(['test']))
+      expect(claimed.id).toBe('legacy')
+
+      // The migrated column is usable for sleep/wake.
+      expect(await storage.sleepRun('legacy', claimed.leaseId, Date.now() - 1)).toBe(true)
+      const woken = expectPresent(await storage.claimNextRun(['test']))
+      expect(woken.id).toBe('legacy')
+    })
+
+    it('is idempotent — initialize on an already-migrated database is a no-op', async () => {
+      await storage.initialize()
+      await storage.initialize()
+      // Still functional.
+      await storage.createRun(makeRun({ id: 'ok' }))
+      expect(expectPresent(await storage.claimNextRun(['test'])).id).toBe('ok')
     })
   })
 })

--- a/src/storage/__tests__/sqlite.test.ts
+++ b/src/storage/__tests__/sqlite.test.ts
@@ -421,4 +421,44 @@ describe('SQLiteStorage', () => {
       await storage.initialize()
     })
   })
+
+  describe('sleepRun / wake', () => {
+    it('suspends a claimed run; a non-matching lease cannot', async () => {
+      await storage.createRun(makeRun({ id: 'run_1' }))
+      const claimed = expectPresent(await storage.claimNextRun(['test']))
+
+      expect(await storage.sleepRun('run_1', 'wrong-lease', Date.now() + 60_000)).toBe(false)
+      expect(await storage.sleepRun('run_1', claimed.leaseId, Date.now() + 60_000)).toBe(true)
+      expect(expectPresent(await storage.getRun('run_1')).status).toBe('sleeping')
+
+      expect(await storage.claimNextRun(['test'])).toBeNull()
+    })
+
+    it('reclaims a sleeping run after its wake time with a fresh lease', async () => {
+      await storage.createRun(makeRun({ id: 'run_1' }))
+      const claimed = expectPresent(await storage.claimNextRun(['test']))
+      expect(await storage.sleepRun('run_1', claimed.leaseId, Date.now() - 1)).toBe(true)
+
+      const woken = expectPresent(await storage.claimNextRun(['test']))
+      expect(woken.id).toBe('run_1')
+      expect(woken.status).toBe('running')
+      expect(woken.leaseId).not.toBe(claimed.leaseId)
+    })
+
+    it('persists the sleeping state across separate storage instances', async () => {
+      await storage.createRun(makeRun({ id: 'run_1' }))
+      const claimed = expectPresent(await storage.claimNextRun(['test']))
+      await storage.sleepRun('run_1', claimed.leaseId, Date.now() - 1)
+      storage.close()
+
+      const storage2 = new SQLiteStorage(DB_PATH)
+      await storage2.initialize()
+      const woken = expectPresent(await storage2.claimNextRun(['test']))
+      expect(woken.id).toBe('run_1')
+      storage2.close()
+
+      storage = new SQLiteStorage(DB_PATH)
+      await storage.initialize()
+    })
+  })
 })

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -72,8 +72,13 @@ export class MemoryStorage implements StorageAdapter {
         return staleBefore !== undefined && run.status === 'running' && run.updatedAt <= staleBefore
       })
       .sort((left, right) => {
-        if (left.status !== right.status) {
-          return left.status === 'pending' ? -1 : 1
+        // Pending runs are claimed before woken sleeping / stale running runs;
+        // within a rank, oldest first. Rank-based so the comparator stays a
+        // valid total order when both non-pending kinds are present.
+        const rank = (status: RunStatus): number => (status === 'pending' ? 0 : 1)
+        const rankDiff = rank(left.status) - rank(right.status)
+        if (rankDiff !== 0) {
+          return rankDiff
         }
         return left.createdAt - right.createdAt
       })

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -11,6 +11,7 @@ import { clonePersistedValue } from './codec'
 
 interface StoredRun extends WorkflowRun {
   leaseId: string | null
+  wakeAt: number | null
 }
 
 export class MemoryStorage implements StorageAdapter {
@@ -38,6 +39,7 @@ export class MemoryStorage implements StorageAdapter {
       ...run,
       input: clonePersistedValue(run.input, 'Workflow input'),
       leaseId: null,
+      wakeAt: null,
     }
 
     this.runs.set(run.id, storedRun)
@@ -52,6 +54,7 @@ export class MemoryStorage implements StorageAdapter {
       return null
     }
 
+    const now = Date.now()
     const candidates = Array.from(this.runs.values())
       .filter((run) => {
         if (!workflowNames.includes(run.workflow)) {
@@ -59,6 +62,10 @@ export class MemoryStorage implements StorageAdapter {
         }
 
         if (run.status === 'pending') {
+          return true
+        }
+
+        if (run.status === 'sleeping' && run.wakeAt !== null && run.wakeAt <= now) {
           return true
         }
 
@@ -79,6 +86,7 @@ export class MemoryStorage implements StorageAdapter {
     run.status = 'running'
     run.updatedAt = Date.now()
     run.leaseId = randomUUID()
+    run.wakeAt = null
 
     return cloneClaimedRun(run)
   }
@@ -89,6 +97,19 @@ export class MemoryStorage implements StorageAdapter {
       return false
     }
 
+    run.updatedAt = Date.now()
+    return true
+  }
+
+  async sleepRun(runId: string, leaseId: string, wakeAt: number): Promise<boolean> {
+    const run = this.runs.get(runId)
+    if (!run || run.status !== 'running' || run.leaseId !== leaseId) {
+      return false
+    }
+
+    run.status = 'sleeping'
+    run.leaseId = null
+    run.wakeAt = wakeAt
     run.updatedAt = Date.now()
     return true
   }
@@ -136,6 +157,7 @@ export class MemoryStorage implements StorageAdapter {
     run.status = status
     run.updatedAt = Date.now()
     run.leaseId = null
+    run.wakeAt = null
 
     return true
   }
@@ -151,6 +173,7 @@ export class MemoryStorage implements StorageAdapter {
 
     if (status !== 'running') {
       run.leaseId = null
+      run.wakeAt = null
     }
 
     return true

--- a/src/storage/sqlite-bun.ts
+++ b/src/storage/sqlite-bun.ts
@@ -88,6 +88,7 @@ export class SQLiteStorage implements StorageAdapter {
         idempotency_key  TEXT,
         lease_id         TEXT,
         status           TEXT NOT NULL,
+        wake_at          INTEGER,
         created_at       INTEGER NOT NULL,
         updated_at       INTEGER NOT NULL
       );
@@ -105,8 +106,17 @@ export class SQLiteStorage implements StorageAdapter {
       );
     `)
 
+    // Migrate databases created before the wake_at column existed.
+    const columns = this.db
+      .prepare<{ name: string }>(`PRAGMA table_info(workflow_runs)`)
+      .all()
+    if (!columns.some((column) => column.name === 'wake_at')) {
+      this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN wake_at INTEGER`)
+    }
+
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status, workflow);
+      CREATE INDEX IF NOT EXISTS idx_runs_wake ON workflow_runs(status, wake_at);
       CREATE INDEX IF NOT EXISTS idx_steps_run_id ON workflow_steps(run_id);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_workflow_idempotency
       ON workflow_runs(workflow, idempotency_key)
@@ -188,12 +198,17 @@ export class SQLiteStorage implements StorageAdapter {
 
     const placeholders = workflowNames.map(() => '?').join(', ')
     const claim = this.db.transaction(() => {
-      const reclaimClause = staleBefore === undefined
-        ? `status = 'pending'`
-        : `(status = 'pending' OR (status = 'running' AND updated_at <= ?))`
-      const queryArgs = staleBefore === undefined
-        ? [...workflowNames]
-        : [...workflowNames, staleBefore]
+      const now = Date.now()
+      const conditions = [
+        `status = 'pending'`,
+        `(status = 'sleeping' AND wake_at IS NOT NULL AND wake_at <= ?)`,
+      ]
+      const clauseParams: number[] = [now]
+      if (staleBefore !== undefined) {
+        conditions.push(`(status = 'running' AND updated_at <= ?)`)
+        clauseParams.push(staleBefore)
+      }
+      const reclaimClause = `(${conditions.join(' OR ')})`
 
       const row = this.db
         .prepare<WorkflowRunRow>(
@@ -202,28 +217,20 @@ export class SQLiteStorage implements StorageAdapter {
            ORDER BY CASE status WHEN 'pending' THEN 0 ELSE 1 END ASC, created_at ASC, rowid ASC
            LIMIT 1`,
         )
-        .get(...queryArgs)
+        .get(...workflowNames, ...clauseParams)
 
       if (!row) {
         return null
       }
 
-      const now = Date.now()
       const leaseId = randomUUID()
-      const updateWhere = staleBefore === undefined
-        ? `id = ? AND status = 'pending'`
-        : `id = ? AND (status = 'pending' OR (status = 'running' AND updated_at <= ?))`
-      const updateArgs = staleBefore === undefined
-        ? [leaseId, now, row.id]
-        : [leaseId, now, row.id, staleBefore]
-
       const updated = this.db
         .prepare(
           `UPDATE workflow_runs
-           SET status = 'running', lease_id = ?, updated_at = ?
-           WHERE ${updateWhere}`,
+           SET status = 'running', lease_id = ?, wake_at = NULL, updated_at = ?
+           WHERE id = ? AND ${reclaimClause}`,
         )
-        .run(...updateArgs)
+        .run(leaseId, now, row.id, ...clauseParams)
 
       if (updated.changes === 0) {
         return null
@@ -248,6 +255,18 @@ export class SQLiteStorage implements StorageAdapter {
          WHERE id = ? AND status = 'running' AND lease_id = ?`,
       )
       .run(Date.now(), runId, leaseId)
+
+    return result.changes > 0
+  }
+
+  async sleepRun(runId: string, leaseId: string, wakeAt: number): Promise<boolean> {
+    const result = this.db
+      .prepare(
+        `UPDATE workflow_runs
+         SET status = 'sleeping', lease_id = NULL, wake_at = ?, updated_at = ?
+         WHERE id = ? AND status = 'running' AND lease_id = ?`,
+      )
+      .run(wakeAt, Date.now(), runId, leaseId)
 
     return result.changes > 0
   }
@@ -320,7 +339,7 @@ export class SQLiteStorage implements StorageAdapter {
     const result = this.db
       .prepare(
         `UPDATE workflow_runs
-         SET status = ?, lease_id = ?, updated_at = ?
+         SET status = ?, lease_id = ?, wake_at = NULL, updated_at = ?
          WHERE id = ?`,
       )
       .run(status, null, Date.now(), runId)
@@ -332,7 +351,7 @@ export class SQLiteStorage implements StorageAdapter {
     const result = this.db
       .prepare(
         `UPDATE workflow_runs
-         SET status = ?, lease_id = ?, updated_at = ?
+         SET status = ?, lease_id = ?, wake_at = NULL, updated_at = ?
          WHERE id = ? AND status = 'running' AND lease_id = ?`,
       )
       .run(status, status === 'running' ? leaseId : null, Date.now(), runId, leaseId)

--- a/src/storage/sqlite-node-builtin.ts
+++ b/src/storage/sqlite-node-builtin.ts
@@ -372,7 +372,11 @@ export class SQLiteStorage implements StorageAdapter {
   }
 
   private transaction<T>(fn: () => T): T {
-    this.db.exec('BEGIN')
+    // BEGIN IMMEDIATE takes the write lock up front. A deferred BEGIN that does
+    // a SELECT then an UPDATE (e.g. claimNextRun) can hit SQLITE_BUSY_SNAPSHOT
+    // under concurrent writers in WAL mode — which busy_timeout does NOT retry.
+    // The better-sqlite3 and bun adapters get this via their native helpers.
+    this.db.exec('BEGIN IMMEDIATE')
     try {
       const result = fn()
       this.db.exec('COMMIT')

--- a/src/storage/sqlite-node-builtin.ts
+++ b/src/storage/sqlite-node-builtin.ts
@@ -78,6 +78,7 @@ export class SQLiteStorage implements StorageAdapter {
         idempotency_key  TEXT,
         lease_id         TEXT,
         status           TEXT NOT NULL,
+        wake_at          INTEGER,
         created_at       INTEGER NOT NULL,
         updated_at       INTEGER NOT NULL
       );
@@ -95,8 +96,15 @@ export class SQLiteStorage implements StorageAdapter {
       );
     `)
 
+    // Migrate databases created before the wake_at column existed.
+    const columns = this.all<{ name: string }>(`PRAGMA table_info(workflow_runs)`)
+    if (!columns.some((column) => column.name === 'wake_at')) {
+      this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN wake_at INTEGER`)
+    }
+
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status, workflow);
+      CREATE INDEX IF NOT EXISTS idx_runs_wake ON workflow_runs(status, wake_at);
       CREATE INDEX IF NOT EXISTS idx_steps_run_id ON workflow_steps(run_id);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_workflow_idempotency
       ON workflow_runs(workflow, idempotency_key)
@@ -177,39 +185,40 @@ export class SQLiteStorage implements StorageAdapter {
     const placeholders = workflowNames.map(() => '?').join(', ')
 
     return this.transaction(() => {
-      const reclaimClause = staleBefore === undefined
-        ? `status = 'pending'`
-        : `(status = 'pending' OR (status = 'running' AND updated_at <= ?))`
-      const queryArgs = staleBefore === undefined
-        ? [...workflowNames]
-        : [...workflowNames, staleBefore]
+      const now = Date.now()
+      const conditions = [
+        `status = 'pending'`,
+        `(status = 'sleeping' AND wake_at IS NOT NULL AND wake_at <= ?)`,
+      ]
+      const clauseParams: number[] = [now]
+      if (staleBefore !== undefined) {
+        conditions.push(`(status = 'running' AND updated_at <= ?)`)
+        clauseParams.push(staleBefore)
+      }
+      const reclaimClause = `(${conditions.join(' OR ')})`
 
       const row = this.get<WorkflowRunRow>(
         `SELECT * FROM workflow_runs
          WHERE workflow IN (${placeholders}) AND ${reclaimClause}
          ORDER BY CASE status WHEN 'pending' THEN 0 ELSE 1 END ASC, created_at ASC, rowid ASC
          LIMIT 1`,
-        ...queryArgs,
+        ...workflowNames,
+        ...clauseParams,
       )
 
       if (!row) {
         return null
       }
 
-      const now = Date.now()
       const leaseId = randomUUID()
-      const updateWhere = staleBefore === undefined
-        ? `id = ? AND status = 'pending'`
-        : `id = ? AND (status = 'pending' OR (status = 'running' AND updated_at <= ?))`
-      const updateArgs = staleBefore === undefined
-        ? [leaseId, now, row.id]
-        : [leaseId, now, row.id, staleBefore]
-
       const changes = this.run(
         `UPDATE workflow_runs
-         SET status = 'running', lease_id = ?, updated_at = ?
-         WHERE ${updateWhere}`,
-        ...updateArgs,
+         SET status = 'running', lease_id = ?, wake_at = NULL, updated_at = ?
+         WHERE id = ? AND ${reclaimClause}`,
+        leaseId,
+        now,
+        row.id,
+        ...clauseParams,
       )
 
       if (changes === 0) {
@@ -230,6 +239,20 @@ export class SQLiteStorage implements StorageAdapter {
       `UPDATE workflow_runs
        SET updated_at = ?
        WHERE id = ? AND status = 'running' AND lease_id = ?`,
+      Date.now(),
+      runId,
+      leaseId,
+    )
+
+    return changes > 0
+  }
+
+  async sleepRun(runId: string, leaseId: string, wakeAt: number): Promise<boolean> {
+    const changes = this.run(
+      `UPDATE workflow_runs
+       SET status = 'sleeping', lease_id = NULL, wake_at = ?, updated_at = ?
+       WHERE id = ? AND status = 'running' AND lease_id = ?`,
+      wakeAt,
       Date.now(),
       runId,
       leaseId,
@@ -298,7 +321,7 @@ export class SQLiteStorage implements StorageAdapter {
   async updateRunStatus(runId: string, status: RunStatus): Promise<boolean> {
     const changes = this.run(
       `UPDATE workflow_runs
-       SET status = ?, lease_id = ?, updated_at = ?
+       SET status = ?, lease_id = ?, wake_at = NULL, updated_at = ?
        WHERE id = ?`,
       status,
       null,
@@ -312,7 +335,7 @@ export class SQLiteStorage implements StorageAdapter {
   async updateClaimedRunStatus(runId: string, leaseId: string, status: RunStatus): Promise<boolean> {
     const changes = this.run(
       `UPDATE workflow_runs
-       SET status = ?, lease_id = ?, updated_at = ?
+       SET status = ?, lease_id = ?, wake_at = NULL, updated_at = ?
        WHERE id = ? AND status = 'running' AND lease_id = ?`,
       status,
       status === 'running' ? leaseId : null,

--- a/src/storage/sqlite-node.ts
+++ b/src/storage/sqlite-node.ts
@@ -62,6 +62,7 @@ export class SQLiteStorage implements StorageAdapter {
         idempotency_key  TEXT,
         lease_id         TEXT,
         status           TEXT NOT NULL,
+        wake_at          INTEGER,
         created_at       INTEGER NOT NULL,
         updated_at       INTEGER NOT NULL
       );
@@ -79,8 +80,15 @@ export class SQLiteStorage implements StorageAdapter {
       );
     `)
 
+    // Migrate databases created before the wake_at column existed.
+    const columns = this.db.prepare(`PRAGMA table_info(workflow_runs)`).all() as { name: string }[]
+    if (!columns.some((column) => column.name === 'wake_at')) {
+      this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN wake_at INTEGER`)
+    }
+
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status, workflow);
+      CREATE INDEX IF NOT EXISTS idx_runs_wake ON workflow_runs(status, wake_at);
       CREATE INDEX IF NOT EXISTS idx_steps_run_id ON workflow_steps(run_id);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_workflow_idempotency
       ON workflow_runs(workflow, idempotency_key)
@@ -162,12 +170,17 @@ export class SQLiteStorage implements StorageAdapter {
 
     const placeholders = workflowNames.map(() => '?').join(', ')
     const claim = this.db.transaction(() => {
-      const reclaimClause = staleBefore === undefined
-        ? `status = 'pending'`
-        : `(status = 'pending' OR (status = 'running' AND updated_at <= ?))`
-      const queryArgs = staleBefore === undefined
-        ? workflowNames
-        : [...workflowNames, staleBefore]
+      const now = Date.now()
+      const conditions = [
+        `status = 'pending'`,
+        `(status = 'sleeping' AND wake_at IS NOT NULL AND wake_at <= ?)`,
+      ]
+      const clauseParams: number[] = [now]
+      if (staleBefore !== undefined) {
+        conditions.push(`(status = 'running' AND updated_at <= ?)`)
+        clauseParams.push(staleBefore)
+      }
+      const reclaimClause = `(${conditions.join(' OR ')})`
 
       const row = this.db
         .prepare(
@@ -176,28 +189,20 @@ export class SQLiteStorage implements StorageAdapter {
            ORDER BY CASE status WHEN 'pending' THEN 0 ELSE 1 END ASC, created_at ASC, rowid ASC
            LIMIT 1`,
         )
-        .get(...queryArgs) as WorkflowRunRow | undefined
+        .get(...workflowNames, ...clauseParams) as WorkflowRunRow | undefined
 
       if (!row) {
         return null
       }
 
-      const now = Date.now()
       const leaseId = randomUUID()
-      const updateWhere = staleBefore === undefined
-        ? `id = ? AND status = 'pending'`
-        : `id = ? AND (status = 'pending' OR (status = 'running' AND updated_at <= ?))`
-      const updateArgs = staleBefore === undefined
-        ? [leaseId, now, row.id]
-        : [leaseId, now, row.id, staleBefore]
-
       const result = this.db
         .prepare(
           `UPDATE workflow_runs
-           SET status = 'running', lease_id = ?, updated_at = ?
-           WHERE ${updateWhere}`,
+           SET status = 'running', lease_id = ?, wake_at = NULL, updated_at = ?
+           WHERE id = ? AND ${reclaimClause}`,
         )
-        .run(...updateArgs)
+        .run(leaseId, now, row.id, ...clauseParams)
 
       if (result.changes === 0) {
         return null
@@ -222,6 +227,18 @@ export class SQLiteStorage implements StorageAdapter {
          WHERE id = ? AND status = 'running' AND lease_id = ?`,
       )
       .run(Date.now(), runId, leaseId)
+
+    return result.changes > 0
+  }
+
+  async sleepRun(runId: string, leaseId: string, wakeAt: number): Promise<boolean> {
+    const result = this.db
+      .prepare(
+        `UPDATE workflow_runs
+         SET status = 'sleeping', lease_id = NULL, wake_at = ?, updated_at = ?
+         WHERE id = ? AND status = 'running' AND lease_id = ?`,
+      )
+      .run(wakeAt, Date.now(), runId, leaseId)
 
     return result.changes > 0
   }
@@ -294,7 +311,7 @@ export class SQLiteStorage implements StorageAdapter {
     const result = this.db
       .prepare(
         `UPDATE workflow_runs
-         SET status = ?, lease_id = ?, updated_at = ?
+         SET status = ?, lease_id = ?, wake_at = NULL, updated_at = ?
          WHERE id = ?`,
       )
       .run(status, null, Date.now(), runId)
@@ -306,7 +323,7 @@ export class SQLiteStorage implements StorageAdapter {
     const result = this.db
       .prepare(
         `UPDATE workflow_runs
-         SET status = ?, lease_id = ?, updated_at = ?
+         SET status = ?, lease_id = ?, wake_at = NULL, updated_at = ?
          WHERE id = ? AND status = 'running' AND lease_id = ?`,
       )
       .run(status, status === 'running' ? leaseId : null, Date.now(), runId, leaseId)

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
             { text: 'Failure Handling', link: '/guide/failure-handling' },
             { text: 'Parallel Steps', link: '/guide/parallel' },
             { text: 'Early Completion', link: '/guide/early-completion' },
+            { text: 'Durable Sleep', link: '/guide/sleep' },
             { text: 'Hooks', link: '/guide/hooks' },
             { text: 'Streaming Results', link: '/guide/streaming' },
             { text: 'Cancellation', link: '/guide/cancellation' },

--- a/website/api/events.md
+++ b/website/api/events.md
@@ -23,6 +23,8 @@ type EngineEvent =
 | `runComplete` | A run finishes successfully; `output` is the final result |
 | `runFailed` | A run fails; `stepName` is the offending step, `error` the cause |
 
+A [`.sleep()`](/api/workflow) reuses the step events: `stepStart` fires when the sleep begins and `stepComplete` (with `output: null`) fires when it elapses. While suspended in between, the run's status is `sleeping` (observable via [`getRunStatus()`](/api/engine)).
+
 Checking `event.type` narrows the rest of the fields:
 
 ```typescript

--- a/website/api/types.md
+++ b/website/api/types.md
@@ -14,8 +14,8 @@ Everything stored as workflow input or step output must be a `PersistedValue`. S
 ## Runs and steps
 
 ```typescript
-type RunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
-type StepStatus = 'pending' | 'running' | 'completed' | 'completed-early' | 'failed'
+type RunStatus = 'pending' | 'running' | 'sleeping' | 'completed' | 'failed' | 'cancelled'
+type StepStatus = 'pending' | 'running' | 'completed' | 'completed-early' | 'sleeping' | 'failed'
 ```
 
 | Type | Shape |

--- a/website/api/workflow.md
+++ b/website/api/workflow.md
@@ -60,6 +60,18 @@ Adds a group of concurrent steps. `branches` is a record of `{ branchName: handl
 
 Each branch accepts the same handler/config form as `.step()`. Branch names share the step namespace — duplicates throw [`DuplicateStepError`](/api/errors). At least one branch is required. Calling `complete()` inside a branch throws [`ParallelCompleteError`](/api/errors). See [Parallel Steps](/guide/parallel).
 
+## `.sleep(name, duration)`
+
+Durably pauses the workflow for `duration` before the next step. The run is persisted as `sleeping` and its lease released, so the process can exit during the wait; any engine instance resumes it once the time elapses. `prev` passes through unchanged.
+
+```typescript
+.step('start-trial', async ({ input }) => provisionTrial(input.userId))
+.sleep('trial-period', '14d')
+.step('charge', async ({ input }) => convertOrExpire(input.userId))
+```
+
+`duration` is a number of milliseconds or a string with a unit suffix (`'500ms'`, `'30s'`, `'15m'`, `'24h'`, `'7d'`); an invalid value throws [`ConfigError`](/api/errors). `name` shares the step namespace — duplicates throw [`DuplicateStepError`](/api/errors). See [Durable Sleep](/guide/sleep).
+
 ## `.onFailure(handler)`
 
 Attaches a compensation handler, called when a step fails after exhausting its retries.

--- a/website/guide/sleep.md
+++ b/website/guide/sleep.md
@@ -1,0 +1,56 @@
+# Durable Sleep
+
+`.sleep(name, duration)` durably pauses a workflow between steps. Unlike `await new Promise(r => setTimeout(r, ms))`, the wait survives a process exit, deploy, or crash: the run is persisted as `sleeping` and its lease released, so the process can shut down entirely during the delay. Once the time elapses, any engine instance reclaims the run and continues from the next step.
+
+```typescript
+const workflow = createWorkflow({ name: 'trial', input: z.object({ userId: z.string() }) })
+  .step('start-trial', async ({ input }) => {
+    await provisionTrial(input.userId)
+    return { startedAt: Date.now() }
+  })
+  .sleep('trial-period', '14d')
+  .step('charge-or-expire', async ({ input }) => {
+    await convertOrExpire(input.userId)
+  })
+```
+
+The engine does not hold a timer or keep the process alive for 14 days — it persists a wake time and moves on. When `start()` is polling (or on the next `tick()`) after the wake time, the run resumes.
+
+## Duration format
+
+`duration` is either a number of milliseconds or a string with a single unit suffix:
+
+| Example | Meaning |
+|---|---|
+| `5000` | 5000 ms |
+| `'500ms'` | 500 milliseconds |
+| `'30s'` | 30 seconds |
+| `'15m'` | 15 minutes |
+| `'24h'` | 24 hours |
+| `'7d'` | 7 days |
+
+An invalid duration throws [`ConfigError`](/api/errors) when the workflow is defined.
+
+## Behaviour
+
+- **`prev` passes through.** A sleep produces no output; the next step receives the previous step's output as `prev`, unchanged.
+- **The name must be unique** within the workflow (like a step), and the sleep appears in [`getRunStatus()`](/api/engine) as a step — `sleeping` while waiting, then `completed` once it elapses.
+- **Wake granularity** is the engine poll interval (default 1s). A run sleeping until time *T* resumes on the first `tick()` at or after *T*, not at *T* exactly.
+- **Crash-safe.** The wake time is persisted before the run is suspended, so a restart does not restart the timer or skip the wait.
+- **Cancellable.** [`cancel()`](/api/engine) works on a sleeping run; it never resumes.
+
+## Resuming on another machine
+
+Because the wait lives in storage rather than in process memory, a completely separate engine instance can resume the run:
+
+```typescript
+// Process A enqueues and runs up to the sleep, then exits.
+await engineA.tick() // → run is now 'sleeping'
+
+// Hours later, process B (sharing the same database) resumes it automatically.
+await engineB.start() // polls, reclaims the woken run, finishes it
+```
+
+## Zero-length sleep
+
+`.sleep('noop', 0)` (or any already-elapsed duration) completes in the same tick without suspending — useful when a duration is computed and may be zero.


### PR DESCRIPTION
## Summary

Adds **durable sleep** — `.sleep(name, duration)` pauses a workflow between steps for a delay that survives process exit, deploy, or crash. This moves Reflow from "durable *between* steps" to "durable *across* time": a workflow can wait hours or days without holding a timer or keeping the process alive.

```typescript
createWorkflow({ name: 'trial', input: z.object({ userId: z.string() }) })
  .step('start-trial', async ({ input }) => provisionTrial(input.userId))
  .sleep('trial-period', '14d')
  .step('charge-or-expire', async ({ input }) => convertOrExpire(input.userId))
```

The run is persisted as `sleeping` with its lease released; any engine instance reclaims and resumes it once the wake time passes. `prev` passes through unchanged, and the sleep is observable as a step (`sleeping` → `completed`).

## Design

Suspension is modelled as a new **execution unit** at the step boundary (alongside `step` and `parallel`), which fits Reflow's replay model exactly — no determinism constraints are imposed on handler code.

- `duration` is a number of milliseconds or a unit-suffixed string (`'500ms'`, `'30s'`, `'15m'`, `'24h'`, `'7d'`), parsed by a new zero-dependency parser. Invalid values throw `ConfigError`.
- `RunStatus` / `StepStatus` gain `sleeping`.
- `StorageAdapter` gains `sleepRun(runId, leaseId, wakeAt)`; `claimNextRun` now also reclaims `sleeping` runs whose wake time has passed. Implemented across all four built-in adapters. The SQLite adapters add a `wake_at` column via an automatic, backward-compatible migration (`PRAGMA table_info` → conditional `ALTER TABLE`).
- Wake granularity is the engine poll interval; cancellation works on a sleeping run; a zero-length sleep completes in the same tick without suspending.

## Bundled fix — bun adapter change detection

While validating the bun adapter under Bun, this surfaced a pre-existing bug: `bun:sqlite` reports affected-row counts on the `run()` result, **not** on `Database.changes` (which is `undefined`). The adapter read the latter, so `heartbeatRun`, `updateRunStatus`, `updateClaimedRunStatus`, and the `claimNextRun` double-claim guard never reflected real counts. Fixed to read the count from the statement result. (Documented under *Fixed* in the changelog.)

## Tests

- `duration.test.ts` (5) — parser coverage.
- `sleep.test.ts` (6) — suspend/resume, prev passthrough, zero-length, cross-engine crash recovery, no re-run of earlier steps, cancel-while-sleeping, duplicate-name.
- Adapter contract tests for `sleepRun` + claim-wake across memory / better-sqlite3 / node:sqlite, plus a persistence-across-instances case.
- Bun adapter validated directly under Bun (sleep/wake/heartbeat/claim).

378 tests pass; typecheck, build, and `lint:deps` all green. All changes are additive.

`.waitForEvent()` (external-signal suspension) is intentionally deferred to a follow-up PR to keep this one focused.
