### PR TITLE
fix(sqlite-bun): read affected-row counts from run() result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run on every pull request regardless of base branch, so stacked PRs
+  # (a feature branched off a not-yet-merged fix) still get CI.
   pull_request:
-    branches: [main]
 
 permissions: read-all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         run: bun run lint:deps
       - run: bun run typecheck
       - run: bun run test -- --coverage
+      - name: Smoke-test the bun:sqlite adapter under Bun
+        run: bun run test:bun
       - run: bun run build
 
   node-compat:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`reflow-ts/sqlite-bun` change detection** — `bun:sqlite` reports affected-row counts on the `run()` result, not on `Database.changes` (which is `undefined`). The adapter read the latter, so `heartbeatRun`, `updateRunStatus`, `updateClaimedRunStatus`, and the `claimNextRun` double-claim guard never reflected real row counts — heartbeats always reported the lease lost and the claim guard never engaged. The adapter now reads the count from the statement result. Adds a Bun-native smoke test (`bun run test:bun`) wired into CI so the Bun adapter — which the Node-based Vitest suite cannot load — has real coverage.
+
 ## 0.5.0 — 2026-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "build": "tsdown",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:bun": "bun scripts/smoke-bun-adapter.ts",
     "typecheck": "tsc --noEmit",
     "lint:deps": "syncpack lint",
     "fix:deps": "syncpack fix",

--- a/scripts/smoke-bun-adapter.ts
+++ b/scripts/smoke-bun-adapter.ts
@@ -1,0 +1,62 @@
+/**
+ * Bun-native smoke test for the `reflow-ts/sqlite-bun` adapter.
+ *
+ * The Vitest suite runs under Node, where `bun:sqlite` cannot load, so the Bun
+ * adapter is otherwise uncovered. This script exercises the change-count paths
+ * (claim guard, heartbeat, status updates) that depend on reading affected-row
+ * counts from `run()` — the class of bug that `db.changes` (undefined on Bun)
+ * silently broke. Run with `bun run scripts/smoke-bun-adapter.ts`; it throws on
+ * the first failed assertion so CI fails loudly.
+ */
+import { SQLiteStorage } from '../src/storage/sqlite-bun'
+import type { WorkflowRun } from '../src/core/types'
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`smoke-bun-adapter: ${message}`)
+}
+
+function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  const now = Date.now()
+  return {
+    id: 'run_1',
+    workflow: 'test',
+    input: {},
+    idempotencyKey: null,
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+const storage = new SQLiteStorage(':memory:')
+await storage.initialize()
+
+// Claim guard: a claimed run must not be claimable again (depends on the
+// UPDATE's affected-row count, which `db.changes` reported as undefined).
+await storage.createRun(makeRun({ id: 'run_1' }))
+const claimed = await storage.claimNextRun(['test'])
+assert(claimed, 'first claim should succeed')
+assert((await storage.claimNextRun(['test'])) === null, 'double-claim must be prevented')
+
+// Heartbeat must reflect lease ownership.
+assert(await storage.heartbeatRun('run_1', claimed.leaseId), 'heartbeat with held lease should succeed')
+assert(!(await storage.heartbeatRun('run_1', 'wrong-lease')), 'heartbeat with wrong lease should fail')
+
+// Lease-checked status update.
+assert(
+  !(await storage.updateClaimedRunStatus('run_1', 'wrong-lease', 'completed')),
+  'claimed-status update with wrong lease should fail',
+)
+assert(
+  await storage.updateClaimedRunStatus('run_1', claimed.leaseId, 'completed'),
+  'claimed-status update with held lease should succeed',
+)
+assert((await storage.getRun('run_1'))?.status === 'completed', 'run should be completed')
+
+// updateRunStatus existence reporting.
+assert(!(await storage.updateRunStatus('missing', 'cancelled')), 'updateRunStatus on missing run should return false')
+
+storage.close()
+// eslint-disable-next-line no-console
+console.log('OK: sqlite-bun adapter change-count paths verified under Bun')

--- a/src/storage/sqlite-bun.ts
+++ b/src/storage/sqlite-bun.ts
@@ -29,11 +29,17 @@ interface BunDatabase {
   prepare<T = Record<string, unknown>>(sql: string): BunStatement<T>
   transaction<T>(fn: () => T): () => T
   close(): void
-  readonly changes: number
+}
+
+interface BunRunResult {
+  changes: number
+  lastInsertRowid: number | bigint
 }
 
 interface BunStatement<T = Record<string, unknown>> {
-  run(...params: unknown[]): void
+  // bun:sqlite reports affected-row counts on the run() result, not on the
+  // Database instance (db.changes is undefined), so callers must read it here.
+  run(...params: unknown[]): BunRunResult
   get(...params: unknown[]): T | null
   all(...params: unknown[]): T[]
 }
@@ -211,7 +217,7 @@ export class SQLiteStorage implements StorageAdapter {
         ? [leaseId, now, row.id]
         : [leaseId, now, row.id, staleBefore]
 
-      this.db
+      const updated = this.db
         .prepare(
           `UPDATE workflow_runs
            SET status = 'running', lease_id = ?, updated_at = ?
@@ -219,7 +225,7 @@ export class SQLiteStorage implements StorageAdapter {
         )
         .run(...updateArgs)
 
-      if (this.db.changes === 0) {
+      if (updated.changes === 0) {
         return null
       }
 
@@ -235,7 +241,7 @@ export class SQLiteStorage implements StorageAdapter {
   }
 
   async heartbeatRun(runId: string, leaseId: string): Promise<boolean> {
-    this.db
+    const result = this.db
       .prepare(
         `UPDATE workflow_runs
          SET updated_at = ?
@@ -243,7 +249,7 @@ export class SQLiteStorage implements StorageAdapter {
       )
       .run(Date.now(), runId, leaseId)
 
-    return this.db.changes > 0
+    return result.changes > 0
   }
 
   async getRun(runId: string): Promise<WorkflowRun | null> {
@@ -311,7 +317,7 @@ export class SQLiteStorage implements StorageAdapter {
   }
 
   async updateRunStatus(runId: string, status: RunStatus): Promise<boolean> {
-    this.db
+    const result = this.db
       .prepare(
         `UPDATE workflow_runs
          SET status = ?, lease_id = ?, updated_at = ?
@@ -319,11 +325,11 @@ export class SQLiteStorage implements StorageAdapter {
       )
       .run(status, null, Date.now(), runId)
 
-    return this.db.changes > 0
+    return result.changes > 0
   }
 
   async updateClaimedRunStatus(runId: string, leaseId: string, status: RunStatus): Promise<boolean> {
-    this.db
+    const result = this.db
       .prepare(
         `UPDATE workflow_runs
          SET status = ?, lease_id = ?, updated_at = ?
@@ -331,7 +337,7 @@ export class SQLiteStorage implements StorageAdapter {
       )
       .run(status, status === 'running' ? leaseId : null, Date.now(), runId, leaseId)
 
-    return this.db.changes > 0
+    return result.changes > 0
   }
 
   close(): void {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
       exclude: [
         'src/**/__tests__/**',
         'src/**/*.test.ts',
+        // Single-runtime adapters: not loadable in the default (Bun) coverage
+        // run. Each is exercised in its own runtime — sqlite-bun via the Bun
+        // smoke test (`bun run test:bun`), sqlite-node-builtin via the
+        // `node-sqlite` CI job on Node — so neither can be measured here.
         'src/storage/sqlite-bun.ts',
+        'src/storage/sqlite-node-builtin.ts',
         'src/index.ts',
         'src/core/types.ts',
       ],


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug in the `reflow-ts/sqlite-bun` adapter. `bun:sqlite` reports affected-row counts on the **`run()` result object** (`{ changes, lastInsertRowid }`), not on `Database.changes` (which is `undefined` on Bun). The adapter read `this.db.changes`, so several lease/durability guards never saw real row counts:

- `heartbeatRun` always returned `false` → an active worker would appear to have **lost its lease on every heartbeat**.
- `updateRunStatus` / `updateClaimedRunStatus` returned `false` even on success.
- The `claimNextRun` double-claim guard (`if (changes === 0) return null`) never engaged → **two workers could claim the same run** under contention.

The fix reads the count from the statement result in all four methods. No behavioural change on the Node adapters.

## Why it went unnoticed

The Node-based Vitest suite cannot load `bun:sqlite`, so the Bun adapter had **zero automated coverage**. This PR adds a Bun-native smoke test (`scripts/smoke-bun-adapter.ts`, `bun run test:bun`) that exercises the change-count paths, wired into the CI `test` job (which already runs under Bun). The smoke test fails on the pre-fix code and passes after.

## Scope

Foundational fix on `main`. The in-flight feature PRs that touch the Bun adapter (#49 `requeueRun`, #51 `sleepRun`) are rebased on top of this so they inherit correct change detection rather than duplicating the fix.

Verified: `typecheck`, `test` (360), `build`, `lint:deps`, and `test:bun` all pass.
