### PR TITLE
ci: bump codeql-action to 4.37.0 and group its bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,11 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    groups:
+      # `github/codeql-action/*` sub-actions must all run the same version — the
+      # analyze step fails outright if init and analyze disagree. Ungrouped,
+      # Dependabot opens one PR per sub-action, and each is individually
+      # unmergeable because it moves only one half of the pair.
+      codeql-action:
+        patterns:
+          - github/codeql-action*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,6 @@ jobs:
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The `github/codeql-action/*` sub-actions must all run the same version. When `init` and `analyze` disagree, the analyze step fails outright:

> Not all workflow steps that use `github/codeql-action` actions use the same version.

The `github-actions` Dependabot config had no `groups`, so each sub-action got its own PR. Every one of those moves only half of the `init`/`analyze` pair, so **each fails CI on its own and none can merge** — while the pinned version stays stuck on the old release indefinitely.

This is visible today: #66 (`init` → 4.37.0) and #67 (`analyze` → 4.37.0) both fail the Analyze job, while #65 (`upload-sarif`) passes only because it lives in a different workflow with no sibling codeql-action step.

## Change

- Move `init`, `analyze`, and `upload-sarif` to 4.37.0 (`99df26d`) in a single commit, so the pair is consistent.
- Add a `codeql-action` Dependabot group so future bumps arrive as one mergeable PR rather than N unmergeable ones.

## Supersedes

Closes #65, #66, #67 — all three land here together.