### PR TITLE
feat: cron schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Cron schedules** — `engine.schedule(name, input, { cron: '0 9 * * 1-5' })` fires on a cron expression rather than a fixed gap. Supports the standard five fields (`minute hour day-of-month month day-of-week`) with wildcards, ranges, lists, a `/step` suffix, three-letter month and day names, and the `@hourly` / `@daily` / `@weekly` / `@monthly` / `@yearly` aliases. The parser is written from scratch — the package still has one runtime dependency.
+
+  **Expressions are evaluated in UTC.** There is no time-zone option, because interpreting cron in a local zone means deciding what a schedule means during a DST gap (a wall-clock time that does not occur) and a DST overlap (one that occurs twice); guessing there produces a scheduler that silently skips or doubles a run twice a year.
+
+  Malformed expressions are rejected by `schedule()` rather than on the first tick, as is an expression that can never occur (`0 0 30 2 *` — the 30th of February). Registration is the last point a bad cadence can reach the caller, since after that the schedule fires unattended. Missed occurrences are skipped, not backfilled, exactly as for intervals.
+
+  `parseCron()` and `nextCronOccurrence()` are exported for validating an expression or previewing its occurrences without registering anything. New exported types: `CronExpression`, `ScheduleSpec`, `ScheduleRecurrence`.
+- **Duration strings for schedule intervals** — `engine.schedule(name, input, { every: '1h' })` accepts the same unit-suffixed form as `.sleep()`. A bare number is still milliseconds, so existing callers are unaffected.
+
+### Changed
+
+- **Breaking:** `WorkflowSchedule.intervalMs` is replaced by `recurrence`, a tagged union of `{ kind: 'interval'; intervalMs }` and `{ kind: 'cron'; expression }`. A union rather than two optional fields, so a schedule cannot be stored with both or neither. This affects code reading `engine.listSchedules()` and anyone implementing a custom `StorageAdapter`; the `StorageAdapter` method signatures themselves are unchanged.
+- The SQLite adapters store the recurrence in a nullable `interval_ms` plus a new `cron` column. 0.6.0 created that table with `interval_ms INTEGER NOT NULL`, which a cron schedule cannot satisfy, and SQLite cannot drop a `NOT NULL` in place — so `initialize()` rebuilds the table when it finds the old shape, preserving existing rows. Automatic and idempotent; **no manual migration is needed**.
+
 ## 0.6.0 — 2026-08-09
 
 Durability beyond the step. A workflow can now pause for days, wait on a

--- a/README.md
+++ b/README.md
@@ -546,6 +546,13 @@ const key = await engine.schedule('cleanup', { olderThanDays: 30 }, 60 * 60 * 10
 await engine.unschedule(key)
 ```
 
+Fires on a fixed interval or a cron expression:
+
+```typescript
+await engine.schedule('cleanup', input, { every: '1h' })
+await engine.schedule('report',  input, { cron: '0 9 * * 1-5' })  // 09:00 weekdays, UTC
+```
+
 Schedules are **stored, not held in memory**, so they survive a restart or a deploy — any
 engine instance running that workflow picks up the next firing. Registering the same key
 again updates that schedule in place (preserving its cadence unless the interval changed),
@@ -888,7 +895,7 @@ Delivers an external event to a run waiting on `waitForEvent(name)`. Returns `fa
 
 Registers a durable recurring schedule. Returns a `Promise<string>` resolving to the schedule's key, for later removal with `engine.unschedule(key)`.
 
-The schedule is persisted, so it survives restarts and deploys. Registering the same key again updates it in place and preserves the existing cadence unless the interval changed. Due firings are claimed atomically, so N instances sharing a schedule still produce one run per interval. `options.key` overrides the identity, which otherwise defaults to a hash of the workflow name, interval, and input. Missed occurrences are skipped rather than backfilled.
+The recurrence is a number of milliseconds, `{ every }` (ms or a duration string), or `{ cron }` (five fields, evaluated in UTC; malformed or unsatisfiable expressions throw at registration). The schedule is persisted, so it survives restarts and deploys. Registering the same key again updates it in place and preserves the existing cadence unless the recurrence changed. Due firings are claimed atomically, so N instances sharing a schedule still produce one run per interval. `options.key` overrides the identity, which otherwise defaults to a hash of the workflow name, interval, and input. Missed occurrences are skipped rather than backfilled.
 
 ### `engine.unschedule(key)`
 

--- a/src/core/__tests__/cron.test.ts
+++ b/src/core/__tests__/cron.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import { parseCron, nextCronOccurrence } from '../cron'
+import { ConfigError } from '../errors'
+
+/** Next occurrence after an ISO instant, as an ISO string — readable expectations. */
+function next(expression: string, after: string): string {
+  return new Date(nextCronOccurrence(parseCron(expression), Date.parse(after))).toISOString()
+}
+
+describe('parseCron', () => {
+  it('expands a wildcard to the whole field', () => {
+    const cron = parseCron('* * * * *')
+
+    expect(cron.minutes.size).toBe(60)
+    expect(cron.hours.size).toBe(24)
+    expect(cron.daysOfMonth.size).toBe(31)
+    expect(cron.months.size).toBe(12)
+  })
+
+  it('parses single values, lists, ranges, and steps', () => {
+    expect([...parseCron('5 * * * *').minutes]).toStrictEqual([5])
+    expect([...parseCron('1,3,5 * * * *').minutes]).toStrictEqual([1, 3, 5])
+    expect([...parseCron('10-13 * * * *').minutes]).toStrictEqual([10, 11, 12, 13])
+    expect([...parseCron('*/15 * * * *').minutes]).toStrictEqual([0, 15, 30, 45])
+    expect([...parseCron('0-30/10 * * * *').minutes]).toStrictEqual([0, 10, 20, 30])
+  })
+
+  it('treats a bare value with a step as an open-ended range', () => {
+    // `5/15` is "from 5 onward, every 15" — not the single value 5.
+    expect([...parseCron('5/15 * * * *').minutes]).toStrictEqual([5, 20, 35, 50])
+  })
+
+  it('accepts month and day names, case-insensitively', () => {
+    expect([...parseCron('0 0 * JAN *').months]).toStrictEqual([1])
+    expect([...parseCron('0 0 * * mon').daysOfWeek]).toStrictEqual([1])
+    expect([...parseCron('0 0 * mar-may *').months]).toStrictEqual([3, 4, 5])
+  })
+
+  it('treats day-of-week 7 and 0 as the same Sunday', () => {
+    expect([...parseCron('0 0 * * 7').daysOfWeek]).toStrictEqual([0])
+    expect([...parseCron('0 0 * * 0').daysOfWeek]).toStrictEqual([0])
+  })
+
+  it('expands the named aliases', () => {
+    expect(next('@daily', '2026-03-10T12:00:00Z')).toBe('2026-03-11T00:00:00.000Z')
+    expect(next('@hourly', '2026-03-10T12:30:00Z')).toBe('2026-03-10T13:00:00.000Z')
+    expect(next('@weekly', '2026-03-10T12:00:00Z')).toBe('2026-03-15T00:00:00.000Z')
+    expect(next('@monthly', '2026-03-10T12:00:00Z')).toBe('2026-04-01T00:00:00.000Z')
+    expect(next('@yearly', '2026-03-10T12:00:00Z')).toBe('2027-01-01T00:00:00.000Z')
+  })
+
+  it('records which day fields were narrowed', () => {
+    const both = parseCron('0 0 13 * 5')
+    expect(both.dayOfMonthRestricted).toBe(true)
+    expect(both.dayOfWeekRestricted).toBe(true)
+
+    const neither = parseCron('0 0 * * *')
+    expect(neither.dayOfMonthRestricted).toBe(false)
+    expect(neither.dayOfWeekRestricted).toBe(false)
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['* * * *', 'four fields'],
+    ['* * * * * *', 'six fields'],
+    ['60 * * * *', 'minute out of range'],
+    ['* 24 * * *', 'hour out of range'],
+    ['* * 0 * *', 'day-of-month below range'],
+    ['* * 32 * *', 'day-of-month above range'],
+    ['* * * 13 *', 'month out of range'],
+    ['* * * * 8', 'day-of-week out of range'],
+    ['30-10 * * * *', 'range runs backwards'],
+    ['*/0 * * * *', 'zero step'],
+    ['*/-1 * * * *', 'negative step'],
+    ['1//2 * * * *', 'double step'],
+    ['nope * * * *', 'not a number'],
+    ['1,,2 * * * *', 'empty list term'],
+  ])('rejects %s (%s)', (expression) => {
+    expect(() => parseCron(expression)).toThrow(ConfigError)
+  })
+})
+
+describe('nextCronOccurrence', () => {
+  it('returns the next matching minute, never the current one', () => {
+    // Exactly on an occurrence must advance, or a schedule would re-fire the
+    // occurrence it just handled.
+    expect(next('*/15 * * * *', '2026-03-10T12:00:00Z')).toBe('2026-03-10T12:15:00.000Z')
+    expect(next('*/15 * * * *', '2026-03-10T12:00:30Z')).toBe('2026-03-10T12:15:00.000Z')
+    expect(next('*/15 * * * *', '2026-03-10T12:14:59Z')).toBe('2026-03-10T12:15:00.000Z')
+  })
+
+  it('rolls forward across hour, day, month, and year boundaries', () => {
+    expect(next('0 * * * *', '2026-03-10T12:30:00Z')).toBe('2026-03-10T13:00:00.000Z')
+    expect(next('0 9 * * *', '2026-03-10T12:00:00Z')).toBe('2026-03-11T09:00:00.000Z')
+    expect(next('0 0 1 * *', '2026-03-10T12:00:00Z')).toBe('2026-04-01T00:00:00.000Z')
+    expect(next('0 0 1 1 *', '2026-03-10T12:00:00Z')).toBe('2027-01-01T00:00:00.000Z')
+  })
+
+  it('handles weekday schedules', () => {
+    // 2026-03-10 is a Tuesday.
+    expect(next('0 9 * * 1-5', '2026-03-10T10:00:00Z')).toBe('2026-03-11T09:00:00.000Z')
+    // Friday 13:00 → the next weekday occurrence is Monday.
+    expect(next('0 9 * * 1-5', '2026-03-13T13:00:00Z')).toBe('2026-03-16T09:00:00.000Z')
+  })
+
+  it('ORs day-of-month with day-of-week when both are restricted', () => {
+    // Cron's oldest quirk. `0 0 13 * 5` means the 13th *or* any Friday.
+    // From Mon 2026-03-09: Friday the 13th is both, so it is the next either way —
+    // the discriminating case is the Friday before the 13th of a later month.
+    expect(next('0 0 13 * 5', '2026-03-09T00:00:00Z')).toBe('2026-03-13T00:00:00.000Z')
+    // April 2026: the 3rd is a Friday, well before the 13th.
+    expect(next('0 0 13 * 5', '2026-04-01T00:00:00Z')).toBe('2026-04-03T00:00:00.000Z')
+  })
+
+  it('ignores day-of-week when only day-of-month is restricted', () => {
+    // The 13th regardless of weekday. 2026-05-13 is a Wednesday.
+    expect(next('0 0 13 * *', '2026-05-01T00:00:00Z')).toBe('2026-05-13T00:00:00.000Z')
+  })
+
+  it('skips months that do not have the requested day', () => {
+    // The 31st: from January, the next is March — February never has one.
+    expect(next('0 0 31 * *', '2026-01-31T12:00:00Z')).toBe('2026-03-31T00:00:00.000Z')
+  })
+
+  it('handles 29 February only in leap years', () => {
+    // 2027 and 2028: the next 29 Feb after 2026 is in 2028.
+    expect(next('0 0 29 2 *', '2026-03-01T00:00:00Z')).toBe('2028-02-29T00:00:00.000Z')
+  })
+
+  it('rejects an expression that can never match', () => {
+    // 30 February. Better to fail loudly than to search forever.
+    expect(() => next('0 0 30 2 *', '2026-01-01T00:00:00Z')).toThrow(ConfigError)
+    expect(() => next('0 0 30 2 *', '2026-01-01T00:00:00Z')).toThrow(/cannot be satisfied/)
+  })
+
+  it('is stable when applied repeatedly', () => {
+    // Feeding each result back in must walk the schedule forward one step at a
+    // time — the property the engine relies on when advancing a claimed row.
+    const cron = parseCron('0 9 * * 1-5')
+    let at = Date.parse('2026-03-09T00:00:00Z')
+    const seen: string[] = []
+
+    for (let i = 0; i < 6; i++) {
+      at = nextCronOccurrence(cron, at)
+      seen.push(new Date(at).toISOString())
+    }
+
+    expect(seen).toStrictEqual([
+      '2026-03-09T09:00:00.000Z',
+      '2026-03-10T09:00:00.000Z',
+      '2026-03-11T09:00:00.000Z',
+      '2026-03-12T09:00:00.000Z',
+      '2026-03-13T09:00:00.000Z',
+      '2026-03-16T09:00:00.000Z',
+    ])
+  })
+
+  it('always returns a time strictly after the input', () => {
+    const cron = parseCron('*/7 */3 * * *')
+    for (const iso of [
+      '2026-01-01T00:00:00Z', '2026-06-15T23:59:59Z',
+      '2026-12-31T23:58:00Z', '2026-02-28T12:34:56Z',
+    ]) {
+      const at = Date.parse(iso)
+      expect(nextCronOccurrence(cron, at)).toBeGreaterThan(at)
+    }
+  })
+
+  it('lands on a zeroed second and millisecond', () => {
+    const at = nextCronOccurrence(parseCron('*/5 * * * *'), Date.parse('2026-03-10T12:01:37.482Z'))
+    const date = new Date(at)
+
+    expect(date.getUTCSeconds()).toBe(0)
+    expect(date.getUTCMilliseconds()).toBe(0)
+  })
+})

--- a/src/core/__tests__/scheduling.test.ts
+++ b/src/core/__tests__/scheduling.test.ts
@@ -174,7 +174,7 @@ describe('durable schedules', () => {
     const schedules = await engine.listSchedules()
     expect(schedules).toHaveLength(1)
     expect(at(schedules, 0).key).toBe(key)
-    expect(at(schedules, 0).intervalMs).toBe(2 * HOUR)
+    expect(at(schedules, 0).recurrence).toStrictEqual({ kind: 'interval', intervalMs: 2 * HOUR })
     expect(at(schedules, 0).nextRunAt).toBe(Date.now() + 2 * HOUR)
   })
 
@@ -319,6 +319,97 @@ describe('durable schedules', () => {
     expect(onError).toHaveBeenCalled()
   })
 
+  it('accepts a duration string as the interval', async () => {
+    const storage = new MemoryStorage()
+    await storage.initialize()
+    const created = trackCreatedRuns(storage)
+
+    const engine = createEngine({ storage, workflows: [cleanup] })
+    await engine.schedule('cleanup', { olderThanDays: 30 }, { every: '1h' })
+
+    vi.advanceTimersByTime(HOUR)
+    await engine.tick()
+
+    expect(created).toHaveLength(1)
+  })
+
+  it('fires a cron schedule at its next occurrence', async () => {
+    vi.setSystemTime(Date.parse('2026-03-10T08:00:00Z'))
+    const storage = new MemoryStorage()
+    await storage.initialize()
+    const created = trackCreatedRuns(storage)
+
+    const engine = createEngine({ storage, workflows: [cleanup] })
+    await engine.schedule('cleanup', { olderThanDays: 30 }, { cron: '0 9 * * *' })
+
+    // 08:30 — not yet due.
+    vi.setSystemTime(Date.parse('2026-03-10T08:30:00Z'))
+    await engine.tick()
+    expect(created).toHaveLength(0)
+
+    // 09:00 — due.
+    vi.setSystemTime(Date.parse('2026-03-10T09:00:00Z'))
+    await engine.tick()
+    expect(created).toHaveLength(1)
+  })
+
+  it('advances a cron schedule to its next occurrence, not by a fixed gap', async () => {
+    // Weekdays at 09:00: from Friday the next firing is Monday, three days on.
+    vi.setSystemTime(Date.parse('2026-03-13T08:00:00Z'))
+    const storage = new MemoryStorage()
+    await storage.initialize()
+
+    const engine = createEngine({ storage, workflows: [cleanup] })
+    await engine.schedule('cleanup', { olderThanDays: 30 }, { cron: '0 9 * * 1-5' })
+
+    vi.setSystemTime(Date.parse('2026-03-13T09:00:00Z'))
+    await engine.tick()
+
+    expect(at(await engine.listSchedules(), 0).nextRunAt).toBe(Date.parse('2026-03-16T09:00:00Z'))
+  })
+
+  it('stores the cron expression as its recurrence', async () => {
+    const storage = new MemoryStorage()
+    await storage.initialize()
+
+    const engine = createEngine({ storage, workflows: [cleanup] })
+    await engine.schedule('cleanup', { olderThanDays: 30 }, { cron: '@daily' })
+
+    expect(at(await engine.listSchedules(), 0).recurrence)
+      .toStrictEqual({ kind: 'cron', expression: '@daily' })
+  })
+
+  it('gives interval and cron schedules of the same workflow distinct keys', async () => {
+    const storage = new MemoryStorage()
+    await storage.initialize()
+
+    const engine = createEngine({ storage, workflows: [cleanup] })
+    const a = await engine.schedule('cleanup', { olderThanDays: 30 }, HOUR)
+    const b = await engine.schedule('cleanup', { olderThanDays: 30 }, { cron: '0 * * * *' })
+
+    expect(a).not.toBe(b)
+    expect(await engine.listSchedules()).toHaveLength(2)
+  })
+
+  it('rejects a malformed cron expression at registration', async () => {
+    // Registration is the last point this can reach a caller; after it the
+    // schedule fires unattended.
+    const engine = createEngine({ storage: new MemoryStorage(), workflows: [cleanup] })
+
+    await expect(engine.schedule('cleanup', { olderThanDays: 1 }, { cron: 'not a cron' }))
+      .rejects.toThrow(ConfigError)
+    await expect(engine.schedule('cleanup', { olderThanDays: 1 }, { cron: '99 * * * *' }))
+      .rejects.toThrow(/out of range/)
+  })
+
+  it('rejects a cron expression that can never occur', async () => {
+    const engine = createEngine({ storage: new MemoryStorage(), workflows: [cleanup] })
+
+    // 30 February. Caught at registration rather than on the first tick.
+    await expect(engine.schedule('cleanup', { olderThanDays: 1 }, { cron: '0 0 30 2 *' }))
+      .rejects.toThrow(ConfigError)
+  })
+
   it('rejects a non-positive interval', async () => {
     const engine = createEngine({ storage: new MemoryStorage(), workflows: [cleanup] })
 
@@ -351,31 +442,31 @@ describe('durable schedules', () => {
 
 describe('nextOccurrence', () => {
   it('leaves a future occurrence untouched', () => {
-    expect(nextOccurrence(1_000, 100, 500)).toBe(1_000)
+    expect(nextOccurrence(1_000, { kind: 'interval', intervalMs: 100 }, 500)).toBe(1_000)
   })
 
   it('advances past now by whole intervals', () => {
-    expect(nextOccurrence(1_000, 100, 1_000)).toBe(1_100)
-    expect(nextOccurrence(1_000, 100, 1_050)).toBe(1_100)
-    expect(nextOccurrence(1_000, 100, 1_100)).toBe(1_200)
+    expect(nextOccurrence(1_000, { kind: 'interval', intervalMs: 100 }, 1_000)).toBe(1_100)
+    expect(nextOccurrence(1_000, { kind: 'interval', intervalMs: 100 }, 1_050)).toBe(1_100)
+    expect(nextOccurrence(1_000, { kind: 'interval', intervalMs: 100 }, 1_100)).toBe(1_200)
   })
 
   it('skips a long outage in one step rather than stepping through it', () => {
     // A year of missed one-second firings must not cost a loop of 31 million.
-    expect(nextOccurrence(0, 1_000, 365 * 24 * 60 * 60 * 1_000)).toBe(31_536_001_000)
+    expect(nextOccurrence(0, { kind: 'interval', intervalMs: 1_000 }, 365 * 24 * 60 * 60 * 1_000)).toBe(31_536_001_000)
   })
 
   it('rejects an interval that would produce NaN rather than writing it', () => {
     // A NaN next_run_at compares false against every clock, so the schedule
     // would stop firing permanently and silently.
     for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
-      expect(() => nextOccurrence(0, bad, 1_000)).toThrow(ConfigError)
+      expect(() => nextOccurrence(0, { kind: 'interval', intervalMs: bad }, 1_000)).toThrow(ConfigError)
     }
   })
 
   it('always returns a time strictly after now', () => {
     for (const now of [0, 1, 99, 100, 101, 12_345]) {
-      expect(nextOccurrence(0, 100, now)).toBeGreaterThan(now)
+      expect(nextOccurrence(0, { kind: 'interval', intervalMs: 100 }, now)).toBeGreaterThan(now)
     }
   })
 })

--- a/src/core/cron.ts
+++ b/src/core/cron.ts
@@ -1,0 +1,287 @@
+import { ConfigError } from './errors'
+
+/**
+ * A minimal, dependency-free cron parser and occurrence calculator.
+ *
+ * Supports the standard five-field form — `minute hour day-of-month month
+ * day-of-week` — with wildcards, single values, `a-b` ranges, a `/step`
+ * suffix on either, comma-separated lists, three-letter month and day names,
+ * and the common `@hourly` / `@daily` / `@weekly` / `@monthly` / `@yearly`
+ * aliases.
+ *
+ * **All times are UTC.** Reflow does not interpret cron expressions in a local
+ * time zone, because doing that correctly means deciding what a schedule means
+ * during a DST gap (a wall-clock time that does not occur) and a DST overlap (one
+ * that occurs twice) — and guessing produces a scheduler that silently skips or
+ * doubles a run twice a year. UTC has no such ambiguity.
+ */
+
+/** A parsed cron expression. Field sets hold every value that matches. */
+export interface CronExpression {
+  /** The expression as written, for error messages and round-tripping. */
+  readonly source: string
+  readonly minutes: ReadonlySet<number>
+  readonly hours: ReadonlySet<number>
+  readonly daysOfMonth: ReadonlySet<number>
+  readonly months: ReadonlySet<number>
+  readonly daysOfWeek: ReadonlySet<number>
+  /**
+   * Whether the day-of-month and day-of-week fields were narrowed from `*`.
+   *
+   * Cron's oldest quirk: when *both* are restricted the fields are OR'd, not
+   * AND'd, so `0 0 13 * 5` means "the 13th, and also every Friday". When only
+   * one is restricted the other is ignored.
+   */
+  readonly dayOfMonthRestricted: boolean
+  readonly dayOfWeekRestricted: boolean
+}
+
+interface FieldSpec {
+  readonly name: string
+  readonly min: number
+  readonly max: number
+  readonly names?: Readonly<Record<string, number>>
+}
+
+const MONTH_NAMES = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+} as const
+
+const DAY_NAMES = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+} as const
+
+const FIELDS: readonly FieldSpec[] = [
+  { name: 'minute', min: 0, max: 59 },
+  { name: 'hour', min: 0, max: 23 },
+  { name: 'day-of-month', min: 1, max: 31 },
+  { name: 'month', min: 1, max: 12, names: MONTH_NAMES },
+  { name: 'day-of-week', min: 0, max: 7, names: DAY_NAMES },
+]
+
+const ALIASES: Readonly<Record<string, string>> = {
+  '@yearly': '0 0 1 1 *',
+  '@annually': '0 0 1 1 *',
+  '@monthly': '0 0 1 * *',
+  '@weekly': '0 0 * * 0',
+  '@daily': '0 0 * * *',
+  '@midnight': '0 0 * * *',
+  '@hourly': '0 * * * *',
+}
+
+/** How far ahead {@link nextCronOccurrence} searches before declaring an expression unsatisfiable. */
+const SEARCH_LIMIT_DAYS = 4 * 366
+
+/**
+ * Parse a cron expression.
+ *
+ * @throws {ConfigError} if the expression is malformed or a field is out of range.
+ */
+export function parseCron(source: string): CronExpression {
+  const trimmed = source.trim()
+  if (trimmed.length === 0) {
+    throw new ConfigError('Cron expression must not be empty')
+  }
+
+  const normalized = ALIASES[trimmed.toLowerCase()] ?? trimmed
+  const parts = normalized.split(/\s+/)
+
+  if (parts.length !== 5) {
+    throw new ConfigError(
+      `Cron expression "${source}" must have 5 fields (minute hour day-of-month month day-of-week), got ${parts.length}`,
+    )
+  }
+
+  const sets = parts.map((part, index) => {
+    const spec = FIELDS[index]
+    if (!spec) {
+      throw new ConfigError(`Cron expression "${source}" has too many fields`)
+    }
+    return parseField(part, spec, source)
+  })
+
+  const [minutes, hours, daysOfMonth, months, dayOfWeekRaw] = sets
+  if (!minutes || !hours || !daysOfMonth || !months || !dayOfWeekRaw) {
+    throw new ConfigError(`Cron expression "${source}" could not be parsed`)
+  }
+
+  // Both 0 and 7 mean Sunday; normalise so matching only has to check one.
+  const daysOfWeek = new Set([...dayOfWeekRaw].map((day) => (day === 7 ? 0 : day)))
+
+  return {
+    source: trimmed,
+    minutes,
+    hours,
+    daysOfMonth,
+    months,
+    daysOfWeek,
+    dayOfMonthRestricted: parts[2] !== '*',
+    dayOfWeekRestricted: parts[4] !== '*',
+  }
+}
+
+function parseField(field: string, spec: FieldSpec, source: string): Set<number> {
+  const values = new Set<number>()
+
+  for (const term of field.split(',')) {
+    if (term.length === 0) {
+      throw new ConfigError(`Cron expression "${source}" has an empty ${spec.name} term`)
+    }
+
+    const [rangePart, stepPart, ...excess] = term.split('/')
+    if (excess.length > 0 || rangePart === undefined) {
+      throw new ConfigError(`Cron ${spec.name} "${term}" in "${source}" has more than one step`)
+    }
+
+    let step = 1
+    if (stepPart !== undefined) {
+      step = Number(stepPart)
+      if (!Number.isInteger(step) || step < 1) {
+        throw new ConfigError(`Cron ${spec.name} step "${stepPart}" in "${source}" must be a positive integer`)
+      }
+    }
+
+    let start: number
+    let end: number
+
+    if (rangePart === '*') {
+      start = spec.min
+      end = spec.max
+    } else {
+      const bounds = rangePart.split('-')
+      if (bounds.length > 2) {
+        throw new ConfigError(`Cron ${spec.name} "${term}" in "${source}" is not a valid range`)
+      }
+      const [lowRaw, highRaw] = bounds
+      start = parseValue(lowRaw, spec, source)
+      // `5/15` means "from 5 to the field maximum, every 15" — a bare value with
+      // a step is an open-ended range, not a single value.
+      end = highRaw !== undefined ? parseValue(highRaw, spec, source) : (stepPart !== undefined ? spec.max : start)
+    }
+
+    if (start > end) {
+      throw new ConfigError(`Cron ${spec.name} range "${term}" in "${source}" starts after it ends`)
+    }
+
+    for (let value = start; value <= end; value += step) {
+      values.add(value)
+    }
+  }
+
+  if (values.size === 0) {
+    throw new ConfigError(`Cron ${spec.name} "${field}" in "${source}" matches nothing`)
+  }
+
+  return values
+}
+
+function parseValue(raw: string | undefined, spec: FieldSpec, source: string): number {
+  if (raw === undefined || raw.length === 0) {
+    throw new ConfigError(`Cron ${spec.name} in "${source}" has an empty value`)
+  }
+
+  const named = spec.names?.[raw.toLowerCase()]
+  const value = named ?? Number(raw)
+
+  if (!Number.isInteger(value)) {
+    throw new ConfigError(`Cron ${spec.name} "${raw}" in "${source}" is not a valid value`)
+  }
+  if (value < spec.min || value > spec.max) {
+    throw new ConfigError(
+      `Cron ${spec.name} "${raw}" in "${source}" is out of range (${spec.min}-${spec.max})`,
+    )
+  }
+
+  return value
+}
+
+/** Whether a given UTC date satisfies the expression's day fields. */
+function matchesDay(cron: CronExpression, date: Date): boolean {
+  if (!cron.months.has(date.getUTCMonth() + 1)) {
+    return false
+  }
+
+  const dayOfMonthMatches = cron.daysOfMonth.has(date.getUTCDate())
+  const dayOfWeekMatches = cron.daysOfWeek.has(date.getUTCDay())
+
+  // The OR quirk: with both fields restricted, either one matching is enough.
+  if (cron.dayOfMonthRestricted && cron.dayOfWeekRestricted) {
+    return dayOfMonthMatches || dayOfWeekMatches
+  }
+  if (cron.dayOfMonthRestricted) {
+    return dayOfMonthMatches
+  }
+  if (cron.dayOfWeekRestricted) {
+    return dayOfWeekMatches
+  }
+  return true
+}
+
+/**
+ * The first time strictly after `after` (epoch ms, UTC) that matches `cron`.
+ *
+ * Searches by whole days rather than by minute, so a sparse expression like
+ * `0 0 1 1 *` costs a few hundred iterations rather than half a million.
+ *
+ * @throws {ConfigError} if nothing matches within four years, which means the
+ * expression is unsatisfiable — `0 0 30 2 *` asks for the 30th of February.
+ */
+export function nextCronOccurrence(cron: CronExpression, after: number): number {
+  // Start at the next whole minute; cron has no sub-minute resolution, and
+  // starting at `after` itself would re-fire the occurrence just handled.
+  const cursor = new Date(after)
+  cursor.setUTCSeconds(0, 0)
+  cursor.setUTCMinutes(cursor.getUTCMinutes() + 1)
+
+  // A wall-clock deadline rather than an iteration counter: every branch below
+  // moves the cursor strictly forward, so the loop provably terminates.
+  const deadline = after + SEARCH_LIMIT_DAYS * 86_400_000
+
+  const nextDay = () => {
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+    cursor.setUTCHours(0, 0, 0, 0)
+  }
+
+  while (cursor.getTime() <= deadline) {
+    if (!matchesDay(cron, cursor)) {
+      nextDay()
+      continue
+    }
+
+    const hour = nextInSet(cron.hours, cursor.getUTCHours())
+    if (hour === null) {
+      nextDay()
+      continue
+    }
+    if (hour !== cursor.getUTCHours()) {
+      // Moved to a later hour, so the minute search restarts from the top of it.
+      cursor.setUTCHours(hour, 0, 0, 0)
+    }
+
+    const minute = nextInSet(cron.minutes, cursor.getUTCMinutes())
+    if (minute === null) {
+      // Rolls into the next hour, and past midnight into the next day if needed.
+      cursor.setUTCHours(cursor.getUTCHours() + 1, 0, 0, 0)
+      continue
+    }
+
+    cursor.setUTCMinutes(minute, 0, 0)
+    return cursor.getTime()
+  }
+
+  throw new ConfigError(
+    `Cron expression "${cron.source}" has no occurrence within four years — it cannot be satisfied`,
+  )
+}
+
+/** The smallest member of `set` that is >= `from`, or null if there is none. */
+function nextInSet(set: ReadonlySet<number>, from: number): number | null {
+  let best: number | null = null
+  for (const value of set) {
+    if (value >= from && (best === null || value < best)) {
+      best = value
+    }
+  }
+  return best
+}

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -18,6 +18,9 @@ import {
   ValidationError,
   WorkflowNotFoundError,
 } from './errors'
+import { parseCron } from './cron'
+import { parseDuration } from './duration'
+import { firstOccurrence } from './schedule-timing'
 import { cloneEngineEvent, type EngineEvent, type EngineHooks } from './events'
 import { parallelExecutor } from './execution/parallel'
 import { sleepExecutor } from './execution/sleep'
@@ -34,6 +37,7 @@ import type {
   StorageAdapter,
   WorkflowRun,
   WorkflowSchedule,
+  ScheduleRecurrence,
 } from './types'
 import type { AnyWorkflow, ExecutionUnit, WorkflowInputMap } from './workflow'
 
@@ -85,6 +89,19 @@ export interface EnqueueOptions {
   /** Prevents duplicate runs. Same key + same input returns the existing run. Same key + different input throws. */
   idempotencyKey?: string
 }
+
+/**
+ * How often a schedule fires.
+ *
+ * A bare number is milliseconds, so existing interval callers are unaffected.
+ * `{ every }` additionally accepts a duration string (`'30s'`, `'24h'`), the
+ * same form `.sleep()` takes. `{ cron }` takes a five-field expression,
+ * evaluated in UTC.
+ */
+export type ScheduleSpec =
+  | number
+  | { readonly every: number | string; readonly cron?: never }
+  | { readonly cron: string; readonly every?: never }
 
 /** Options for `engine.schedule()`. */
 export interface ScheduleOptions {
@@ -150,11 +167,14 @@ export interface Engine<TWorkflowMap extends Record<string, PersistedValue> = Re
    *
    * Occurrences missed while every instance was down are **skipped, not
    * backfilled**: the schedule fires once on return and resumes its cadence.
+   *
+   * Fires on a fixed interval (`60_000`, or `{ every: '1h' }`) or a cron
+   * expression (`{ cron: '0 9 * * 1-5' }`, evaluated in UTC).
    */
   schedule<TName extends string & keyof TWorkflowMap>(
     workflowName: TName,
     input: TWorkflowMap[TName],
-    intervalMs: number,
+    spec: ScheduleSpec,
     options?: ScheduleOptions,
   ): Promise<string>
   /**
@@ -656,28 +676,26 @@ export function createEngine<const TWorkflows extends readonly AnyWorkflow[]>(
   async function schedule(
     workflowName: string,
     input: PersistedValue,
-    intervalMs: number,
+    spec: ScheduleSpec,
     options?: ScheduleOptions,
   ): Promise<string> {
-    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
-      throw new ConfigError('Schedule intervalMs must be a positive number')
-    }
+    const recurrence = parseScheduleSpec(spec)
 
     const wf = registry.get(workflowName)
     if (!wf) throw new WorkflowNotFoundError(workflowName)
 
     const parsedInput = wf.parseInput(input)
-    const key = options?.key ?? deriveScheduleKey(workflowName, intervalMs, parsedInput)
+    const key = options?.key ?? deriveScheduleKey(workflowName, recurrence, parsedInput)
     const now = Date.now()
 
     // `nextRunAt` here is only the value used when the schedule is new (or its
-    // interval changed) — storage preserves an existing cadence otherwise.
+    // recurrence changed) — storage preserves an existing cadence otherwise.
     const stored = await storage.upsertSchedule({
       key,
       workflow: workflowName,
       input: parsedInput,
-      intervalMs,
-      nextRunAt: now + intervalMs,
+      recurrence,
+      nextRunAt: firstOccurrence(recurrence, now),
       createdAt: now,
       updatedAt: now,
     })
@@ -978,15 +996,51 @@ function runWithSignal<T>(
  */
 function deriveScheduleKey(
   workflowName: string,
-  intervalMs: number,
+  recurrence: ScheduleRecurrence,
   input: PersistedValue,
 ): string {
   const canonicalInput = canonicalizePersistedValue(input, 'Schedule input')
+  const cadence = recurrence.kind === 'cron' ? `cron:${recurrence.expression}` : `every:${recurrence.intervalMs}`
 
   return createHash('sha256')
-    .update(`${workflowName}\u0000${intervalMs}\u0000${canonicalInput}`)
+    .update(`${workflowName}\u0000${cadence}\u0000${canonicalInput}`)
     .digest('base64url')
     .slice(0, 22)
+}
+
+/**
+ * Normalise the caller's recurrence, validating it before anything is stored.
+ *
+ * Registration is the last point a bad cadence can be reported to a caller —
+ * after this the schedule fires unattended — so a malformed cron expression is
+ * rejected here rather than on the first tick that tries to advance it.
+ */
+function parseScheduleSpec(spec: ScheduleSpec): ScheduleRecurrence {
+  if (typeof spec === 'number') {
+    return intervalRecurrence(spec)
+  }
+
+  if (spec.every !== undefined) {
+    return intervalRecurrence(typeof spec.every === 'string' ? parseDuration(spec.every) : spec.every)
+  }
+
+  if (spec.cron !== undefined) {
+    // Parsed eagerly and discarded: this is a validation call, and the stored
+    // form stays the expression so it round-trips through storage unchanged.
+    parseCron(spec.cron)
+    return { kind: 'cron', expression: spec.cron.trim() }
+  }
+
+  // Unreachable through the types, but reachable from JavaScript.
+  throw new ConfigError('Schedule must specify either `every` or `cron`')
+}
+
+function intervalRecurrence(intervalMs: number): ScheduleRecurrence {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new ConfigError('Schedule intervalMs must be a positive number')
+  }
+
+  return { kind: 'interval', intervalMs }
 }
 
 function normalizeIdempotencyKey(idempotencyKey?: string): string | null {

--- a/src/core/schedule-timing.ts
+++ b/src/core/schedule-timing.ts
@@ -1,22 +1,37 @@
+import { parseCron, nextCronOccurrence } from './cron'
 import { ConfigError } from './errors'
+import type { ScheduleRecurrence } from './types'
 
 /**
  * The first occurrence strictly after `now`, given a firing that was due at
- * `dueAt` and repeats every `intervalMs`.
+ * `dueAt` under `recurrence`.
  *
  * Missed occurrences are **skipped, not backfilled**: a process down for three
  * hours with an hourly schedule fires once when it returns and then resumes the
  * normal cadence, rather than enqueuing three runs at once. Backfilling a queue
  * of stale work is almost never what a recurring job wants, and it turns an
  * outage into a thundering herd.
- *
- * Computed arithmetically rather than by stepping the interval, so a long
- * outage on a short interval costs one operation instead of millions.
  */
-export function nextOccurrence(dueAt: number, intervalMs: number, now: number): number {
+export function nextOccurrence(
+  dueAt: number,
+  recurrence: ScheduleRecurrence,
+  now: number,
+): number {
+  if (dueAt > now) {
+    return dueAt
+  }
+
+  if (recurrence.kind === 'cron') {
+    // Anchored on `now` rather than on `dueAt`, which is what skips the missed
+    // occurrences: asking from `dueAt` would walk them one at a time.
+    return nextCronOccurrence(parseCron(recurrence.expression), now)
+  }
+
+  const { intervalMs } = recurrence
+
   // A non-positive or non-finite interval would yield NaN, and `NaN <= now` is
   // false forever — the schedule would stop firing and never say why. Only a
-  // corrupted row can reach this (`schedule()` validates the interval), so
+  // corrupted row can reach this (`schedule()` validates on registration), so
   // failing loudly is better than writing a value that silently kills it.
   if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
     throw new ConfigError(
@@ -24,10 +39,26 @@ export function nextOccurrence(dueAt: number, intervalMs: number, now: number): 
     )
   }
 
-  if (dueAt > now) {
-    return dueAt
-  }
-
+  // Computed arithmetically rather than by stepping the interval, so a long
+  // outage on a short interval costs one operation instead of millions.
   const missed = Math.floor((now - dueAt) / intervalMs) + 1
   return dueAt + missed * intervalMs
+}
+
+/** Whether two recurrences describe the same cadence, for cadence-preserving upserts. */
+export function sameRecurrence(left: ScheduleRecurrence, right: ScheduleRecurrence): boolean {
+  if (left.kind === 'cron' && right.kind === 'cron') {
+    return left.expression === right.expression
+  }
+  if (left.kind === 'interval' && right.kind === 'interval') {
+    return left.intervalMs === right.intervalMs
+  }
+  return false
+}
+
+/** The first occurrence of a newly registered schedule, measured from `now`. */
+export function firstOccurrence(recurrence: ScheduleRecurrence, now: number): number {
+  return recurrence.kind === 'cron'
+    ? nextCronOccurrence(parseCron(recurrence.expression), now)
+    : now + recurrence.intervalMs
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -74,6 +74,18 @@ export interface RunInfo {
 }
 
 /**
+ * How a schedule repeats.
+ *
+ * A tagged union rather than two optional fields, so a schedule cannot be
+ * stored with both an interval and a cron expression, or neither.
+ */
+export type ScheduleRecurrence =
+  /** A fixed gap between firings. */
+  | { readonly kind: 'interval'; readonly intervalMs: number }
+  /** A five-field cron expression, evaluated in UTC. */
+  | { readonly kind: 'cron'; readonly expression: string }
+
+/**
  * A durably registered recurring schedule.
  *
  * Unlike a run, a schedule is long-lived and shared: every engine instance
@@ -91,8 +103,8 @@ export interface WorkflowSchedule {
   workflow: string
   /** Validated input handed to each enqueued run. */
   input: PersistedValue
-  /** Gap between firings, in milliseconds. */
-  intervalMs: number
+  /** How the schedule repeats. */
+  recurrence: ScheduleRecurrence
   /** Epoch ms at which this schedule is next due to fire. */
   nextRunAt: number
   createdAt: number
@@ -198,10 +210,10 @@ export interface StorageAdapter {
    * Register a recurring schedule, or update the existing one with the same
    * `key`. Returns the stored schedule.
    *
-   * Re-registering must **preserve `nextRunAt`** when the interval is unchanged,
-   * so a restarting process rejoins the existing cadence instead of pushing the
-   * next firing out by a full interval every deploy. When the interval does
-   * change, the supplied `nextRunAt` takes effect.
+   * Re-registering must **preserve `nextRunAt`** when the recurrence is
+   * unchanged, so a restarting process rejoins the existing cadence instead of
+   * pushing the next firing out by a full interval every deploy. When the
+   * recurrence changes, the supplied `nextRunAt` takes effect.
    */
   upsertSchedule(schedule: WorkflowSchedule): Promise<WorkflowSchedule>
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export { createWorkflow } from './core/workflow'
+export { parseCron, nextCronOccurrence } from './core/cron'
+export type { CronExpression } from './core/cron'
 export { createEngine } from './core/engine'
 export {
   ReflowError,
@@ -50,6 +52,7 @@ export type {
   EngineEventOf,
   EnqueueOptions,
   ScheduleOptions,
+  ScheduleSpec,
   StreamOptions,
   ResultStream,
 } from './core/engine'
@@ -63,6 +66,7 @@ export type {
   StorageAdapter,
   WorkflowRun,
   WorkflowSchedule,
+  ScheduleRecurrence,
   StepResult,
   RunStatus,
   StepStatus,

--- a/src/storage/__tests__/sqlite.test.ts
+++ b/src/storage/__tests__/sqlite.test.ts
@@ -562,6 +562,73 @@ describe('SQLiteStorage', () => {
     })
   })
 
+  describe('cron migration from 0.6', () => {
+    it('rebuilds a 0.6-shaped schedules table so cron rows can be stored', async () => {
+      // 0.6.0 shipped workflow_schedules with `interval_ms INTEGER NOT NULL`
+      // and no cron column. Adding cron alone is not enough — a cron schedule
+      // leaves interval_ms null, which that constraint rejects — so the table
+      // is rebuilt. This is the published schema, so the path is real.
+      storage.close()
+      if (existsSync(DB_PATH)) unlinkSync(DB_PATH)
+
+      const legacy = new Database(DB_PATH)
+      legacy.exec(`
+        CREATE TABLE workflow_schedules (
+          key          TEXT PRIMARY KEY,
+          workflow     TEXT NOT NULL,
+          input        TEXT NOT NULL,
+          interval_ms  INTEGER NOT NULL,
+          next_run_at  INTEGER NOT NULL,
+          created_at   INTEGER NOT NULL,
+          updated_at   INTEGER NOT NULL
+        );
+      `)
+      legacy.prepare(
+        `INSERT INTO workflow_schedules (key, workflow, input, interval_ms, next_run_at, created_at, updated_at)
+         VALUES ('legacy', 'test', '{"olderThanDays":30}', 60000, 5000, 1, 1)`,
+      ).run()
+      legacy.close()
+
+      storage = new SQLiteStorage(DB_PATH)
+      await storage.initialize()
+
+      // The existing interval schedule survives the rebuild intact.
+      const migrated = at(await storage.listSchedules(), 0)
+      expect(migrated.key).toBe('legacy')
+      expect(migrated.recurrence).toStrictEqual({ kind: 'interval', intervalMs: 60_000 })
+      expect(migrated.nextRunAt).toBe(5_000)
+      expect(migrated.input).toStrictEqual({ olderThanDays: 30 })
+
+      // ...and a cron schedule, impossible under the old NOT NULL, now stores.
+      await storage.upsertSchedule({
+        key: 'nightly',
+        workflow: 'test',
+        input: {},
+        recurrence: { kind: 'cron', expression: '0 9 * * *' },
+        nextRunAt: 10_000,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+
+      const schedules = await storage.listSchedules()
+      expect(schedules).toHaveLength(2)
+      expect(at(schedules, 1).recurrence).toStrictEqual({ kind: 'cron', expression: '0 9 * * *' })
+    })
+
+    it('is idempotent — initializing twice does not rebuild again or lose rows', async () => {
+      await storage.upsertSchedule({
+        key: 'keep', workflow: 'test', input: {},
+        recurrence: { kind: 'cron', expression: '0 9 * * *' },
+        nextRunAt: 10_000, createdAt: 1, updatedAt: 1,
+      })
+
+      await storage.initialize()
+      await storage.initialize()
+
+      expect(await storage.listSchedules()).toHaveLength(1)
+    })
+  })
+
   describe('schedules', () => {
     const makeSchedule = (overrides: Partial<WorkflowSchedule> = {}): WorkflowSchedule => {
       const now = Date.now()
@@ -569,7 +636,7 @@ describe('SQLiteStorage', () => {
         key: 'nightly',
         workflow: 'test',
         input: { olderThanDays: 30 },
-        intervalMs: 60_000,
+        recurrence: { kind: 'interval', intervalMs: 60_000 },
         nextRunAt: now + 60_000,
         createdAt: now,
         updatedAt: now,

--- a/src/storage/conformance.ts
+++ b/src/storage/conformance.ts
@@ -85,7 +85,7 @@ function makeSchedule(overrides: Partial<WorkflowSchedule> = {}): WorkflowSchedu
     key: 'nightly',
     workflow: 'test',
     input: { olderThanDays: 30 },
-    intervalMs: 60_000,
+    recurrence: { kind: 'interval', intervalMs: 60_000 },
     nextRunAt: now + 60_000,
     createdAt: now,
     updatedAt: now,
@@ -507,17 +507,17 @@ export const storageConformanceCases: readonly ConformanceCase[] = [
     async run(storage) {
       await storage.upsertSchedule(makeSchedule({ nextRunAt: 5_000 }))
       const changed = await storage.upsertSchedule(
-        makeSchedule({ intervalMs: 120_000, nextRunAt: 900_000 }),
+        makeSchedule({ recurrence: { kind: 'interval', intervalMs: 120_000 }, nextRunAt: 900_000 }),
       )
 
       assertEqual(changed.nextRunAt, 900_000, 'cadence reset')
-      assertEqual(changed.intervalMs, 120_000, 'new interval stored')
+      assertEqual(changed.recurrence, { kind: 'interval', intervalMs: 120_000 }, 'new recurrence stored')
     },
   },
   {
     name: 'claimDueSchedule advances past now and reports the occurrence it fired for',
     async run(storage) {
-      await storage.upsertSchedule(makeSchedule({ nextRunAt: 1_000, intervalMs: 100 }))
+      await storage.upsertSchedule(makeSchedule({ nextRunAt: 1_000, recurrence: { kind: 'interval', intervalMs: 100 } }))
 
       const claimed = await storage.claimDueSchedule(['test'], 1_250)
       assertEqual(claimed?.nextRunAt, 1_000, 'reports the due occurrence')
@@ -528,7 +528,7 @@ export const storageConformanceCases: readonly ConformanceCase[] = [
     name: 'an occurrence can only be claimed once',
     async run(storage) {
       // The atomicity that stops N instances firing one occurrence N times.
-      await storage.upsertSchedule(makeSchedule({ nextRunAt: 1_000, intervalMs: 100_000 }))
+      await storage.upsertSchedule(makeSchedule({ nextRunAt: 1_000, recurrence: { kind: 'interval', intervalMs: 100_000 } }))
 
       assert(await storage.claimDueSchedule(['test'], 1_000), 'first claim succeeds')
       assertEqual(await storage.claimDueSchedule(['test'], 1_000), null, 'second finds nothing due')
@@ -555,6 +555,79 @@ export const storageConformanceCases: readonly ConformanceCase[] = [
     async run(storage) {
       await storage.upsertSchedule(makeSchedule({ nextRunAt: 1_000 }))
       assertEqual(await storage.claimDueSchedule([], 5_000), null, 'no names means nothing claimable')
+    },
+  },
+  {
+    name: 'upsertSchedule round-trips a cron recurrence',
+    async run(storage) {
+      await storage.upsertSchedule(makeSchedule({
+        recurrence: { kind: 'cron', expression: '0 9 * * 1-5' },
+        nextRunAt: 5_000,
+      }))
+
+      const stored = (await storage.listSchedules())[0]
+      assertEqual(stored?.recurrence, { kind: 'cron', expression: '0 9 * * 1-5' }, 'cron recurrence')
+    },
+  },
+  {
+    name: 'upsertSchedule preserves the cadence when the cron expression is unchanged',
+    async run(storage) {
+      const cron = { kind: 'cron', expression: '0 9 * * 1-5' } as const
+      const first = await storage.upsertSchedule(makeSchedule({ recurrence: cron, nextRunAt: 5_000 }))
+      const second = await storage.upsertSchedule(makeSchedule({ recurrence: cron, nextRunAt: 900_000 }))
+
+      assertEqual(second.nextRunAt, first.nextRunAt, 'cadence preserved')
+    },
+  },
+  {
+    name: 'upsertSchedule resets the cadence when the cron expression changes',
+    async run(storage) {
+      await storage.upsertSchedule(makeSchedule({
+        recurrence: { kind: 'cron', expression: '0 9 * * *' },
+        nextRunAt: 5_000,
+      }))
+      const changed = await storage.upsertSchedule(makeSchedule({
+        recurrence: { kind: 'cron', expression: '0 10 * * *' },
+        nextRunAt: 900_000,
+      }))
+
+      assertEqual(changed.nextRunAt, 900_000, 'cadence reset')
+    },
+  },
+  {
+    name: 'switching between interval and cron resets the cadence',
+    async run(storage) {
+      // The two recurrence kinds are distinct cadences even when the stored
+      // columns for the other kind happen to be null on both sides.
+      await storage.upsertSchedule(makeSchedule({
+        recurrence: { kind: 'interval', intervalMs: 60_000 },
+        nextRunAt: 5_000,
+      }))
+      const changed = await storage.upsertSchedule(makeSchedule({
+        recurrence: { kind: 'cron', expression: '0 9 * * *' },
+        nextRunAt: 900_000,
+      }))
+
+      assertEqual(changed.nextRunAt, 900_000, 'cadence reset')
+      assertEqual(changed.recurrence, { kind: 'cron', expression: '0 9 * * *' }, 'recurrence replaced')
+    },
+  },
+  {
+    name: 'claimDueSchedule advances a cron schedule to its next occurrence',
+    async run(storage) {
+      // 09:00 daily; due at 2026-03-10T09:00Z, claimed a minute later.
+      await storage.upsertSchedule(makeSchedule({
+        recurrence: { kind: 'cron', expression: '0 9 * * *' },
+        nextRunAt: Date.parse('2026-03-10T09:00:00Z'),
+      }))
+
+      const claimed = await storage.claimDueSchedule(['test'], Date.parse('2026-03-10T09:01:00Z'))
+      assertEqual(claimed?.nextRunAt, Date.parse('2026-03-10T09:00:00Z'), 'reports the due occurrence')
+      assertEqual(
+        (await storage.listSchedules())[0]?.nextRunAt,
+        Date.parse('2026-03-11T09:00:00Z'),
+        'advances to tomorrow, not by a fixed interval',
+      )
     },
   },
   {

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -11,7 +11,7 @@ import type {
   WorkflowSchedule,
 } from '../core/types'
 import { InternalError } from '../core/errors'
-import { nextOccurrence } from '../core/schedule-timing'
+import { nextOccurrence, sameRecurrence } from '../core/schedule-timing'
 import { clonePersistedValue } from './codec'
 
 interface StoredRun extends WorkflowRun {
@@ -306,7 +306,7 @@ export class MemoryStorage implements StorageAdapter {
       input: clonePersistedValue(schedule.input, 'Schedule input'),
       // A restarting process must rejoin the existing cadence rather than push
       // the next firing out by a full interval on every deploy.
-      nextRunAt: existing && existing.intervalMs === schedule.intervalMs
+      nextRunAt: existing && sameRecurrence(existing.recurrence, schedule.recurrence)
         ? existing.nextRunAt
         : schedule.nextRunAt,
       createdAt: existing?.createdAt ?? schedule.createdAt,
@@ -333,7 +333,7 @@ export class MemoryStorage implements StorageAdapter {
     // these two statements.
     this.schedules.set(due.key, {
       ...due,
-      nextRunAt: nextOccurrence(due.nextRunAt, due.intervalMs, now),
+      nextRunAt: nextOccurrence(due.nextRunAt, due.recurrence, now),
       updatedAt: now,
     })
 

--- a/src/storage/sqlite-bun.ts
+++ b/src/storage/sqlite-bun.ts
@@ -22,6 +22,7 @@ import type {
   StorageAdapter,
   WorkflowRun,
   WorkflowSchedule,
+  ScheduleRecurrence,
 } from '../core/types'
 import { deserializePersistedValue, serializePersistedValue } from './codec'
 import { nextOccurrence } from '../core/schedule-timing'
@@ -75,7 +76,8 @@ interface WorkflowScheduleRow {
   key: string
   workflow: string
   input: string
-  interval_ms: number
+  interval_ms: number | null
+  cron: string | null
   next_run_at: number
   created_at: number
   updated_at: number
@@ -131,7 +133,8 @@ export class SQLiteStorage implements StorageAdapter {
         key          TEXT PRIMARY KEY,
         workflow     TEXT NOT NULL,
         input        TEXT NOT NULL,
-        interval_ms  INTEGER NOT NULL,
+        interval_ms  INTEGER,
+        cron         TEXT,
         next_run_at  INTEGER NOT NULL,
         created_at   INTEGER NOT NULL,
         updated_at   INTEGER NOT NULL
@@ -144,6 +147,35 @@ export class SQLiteStorage implements StorageAdapter {
       .all()
     if (!columns.some((column) => column.name === 'wake_at')) {
       this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN wake_at INTEGER`)
+    }
+
+
+    // 0.6.0 shipped workflow_schedules with a NOT NULL interval_ms and no cron
+    // column. Adding cron alone is not enough: a cron schedule leaves
+    // interval_ms null, which that constraint rejects. SQLite cannot drop a NOT
+    // NULL in place, so the table is rebuilt — cheap, since schedules are few.
+    const scheduleColumns = this.db.prepare(`PRAGMA table_info(workflow_schedules)`).all() as unknown as { name: string }[]
+    if (scheduleColumns.length > 0 && !scheduleColumns.some((column) => column.name === 'cron')) {
+      this.db.exec(`
+        ALTER TABLE workflow_schedules RENAME TO workflow_schedules_old;
+
+        CREATE TABLE workflow_schedules (
+          key          TEXT PRIMARY KEY,
+          workflow     TEXT NOT NULL,
+          input        TEXT NOT NULL,
+          interval_ms  INTEGER,
+          cron         TEXT,
+          next_run_at  INTEGER NOT NULL,
+          created_at   INTEGER NOT NULL,
+          updated_at   INTEGER NOT NULL
+        );
+
+        INSERT INTO workflow_schedules (key, workflow, input, interval_ms, cron, next_run_at, created_at, updated_at)
+        SELECT key, workflow, input, interval_ms, NULL, next_run_at, created_at, updated_at
+        FROM workflow_schedules_old;
+
+        DROP TABLE workflow_schedules_old;
+      `)
     }
 
     this.db.exec(`
@@ -529,20 +561,26 @@ export class SQLiteStorage implements StorageAdapter {
    */
   async upsertSchedule(schedule: WorkflowSchedule): Promise<WorkflowSchedule> {
     const upsert = this.db.transaction(() => {
-      this.db.prepare(`INSERT INTO workflow_schedules (key, workflow, input, interval_ms, next_run_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+      this.db.prepare(`INSERT INTO workflow_schedules (key, workflow, input, interval_ms, cron, next_run_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(key) DO UPDATE SET
            workflow    = excluded.workflow,
            input       = excluded.input,
            interval_ms = excluded.interval_ms,
-           next_run_at = CASE WHEN workflow_schedules.interval_ms = excluded.interval_ms
+           cron        = excluded.cron,
+           -- Keep the existing cadence unless the recurrence itself changed, so
+           -- a redeploy does not push the next firing out every time. IS rather
+           -- than = so a NULL on either side compares correctly.
+           next_run_at = CASE WHEN workflow_schedules.interval_ms IS excluded.interval_ms
+                               AND workflow_schedules.cron IS excluded.cron
                               THEN workflow_schedules.next_run_at
                               ELSE excluded.next_run_at END,
            updated_at  = excluded.updated_at`).run(
         schedule.key,
         schedule.workflow,
         serializePersistedValue(schedule.input, 'Schedule input'),
-        schedule.intervalMs,
+        schedule.recurrence.kind === 'interval' ? schedule.recurrence.intervalMs : null,
+        schedule.recurrence.kind === 'cron' ? schedule.recurrence.expression : null,
         schedule.nextRunAt,
         schedule.createdAt,
         schedule.updatedAt,
@@ -581,7 +619,7 @@ export class SQLiteStorage implements StorageAdapter {
 
       const result = this.db
         .prepare(`UPDATE workflow_schedules SET next_run_at = ?, updated_at = ? WHERE key = ? AND next_run_at = ?`)
-        .run(nextOccurrence(row.next_run_at, row.interval_ms, now), now, row.key, row.next_run_at)
+        .run(nextOccurrence(row.next_run_at, rowRecurrence(row), now), now, row.key, row.next_run_at)
 
       // Guarded on the slot we read, so a racing claim cannot fire it twice.
       if (result.changes === 0) {
@@ -635,12 +673,19 @@ function isUniqueConstraintError(error: unknown): boolean {
     || error.message.includes('UNIQUE constraint failed')
 }
 
+/** The recurrence a schedule row describes: `cron` when set, otherwise the interval. */
+function rowRecurrence(row: WorkflowScheduleRow): ScheduleRecurrence {
+  return row.cron !== null
+    ? { kind: 'cron', expression: row.cron }
+    : { kind: 'interval', intervalMs: row.interval_ms ?? 0 }
+}
+
 function mapWorkflowScheduleRow(row: WorkflowScheduleRow): WorkflowSchedule {
   return {
     key: row.key,
     workflow: row.workflow,
     input: deserializePersistedValue(row.input),
-    intervalMs: row.interval_ms,
+    recurrence: rowRecurrence(row),
     nextRunAt: row.next_run_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/storage/sqlite-node-builtin.ts
+++ b/src/storage/sqlite-node-builtin.ts
@@ -30,6 +30,7 @@ import type {
   StorageAdapter,
   WorkflowRun,
   WorkflowSchedule,
+  ScheduleRecurrence,
 } from '../core/types'
 import { deserializePersistedValue, serializePersistedValue } from './codec'
 import { nextOccurrence } from '../core/schedule-timing'
@@ -67,7 +68,8 @@ interface WorkflowScheduleRow {
   key: string
   workflow: string
   input: string
-  interval_ms: number
+  interval_ms: number | null
+  cron: string | null
   next_run_at: number
   created_at: number
   updated_at: number
@@ -122,7 +124,8 @@ export class SQLiteStorage implements StorageAdapter {
         key          TEXT PRIMARY KEY,
         workflow     TEXT NOT NULL,
         input        TEXT NOT NULL,
-        interval_ms  INTEGER NOT NULL,
+        interval_ms  INTEGER,
+        cron         TEXT,
         next_run_at  INTEGER NOT NULL,
         created_at   INTEGER NOT NULL,
         updated_at   INTEGER NOT NULL
@@ -133,6 +136,35 @@ export class SQLiteStorage implements StorageAdapter {
     const columns = this.all<{ name: string }>(`PRAGMA table_info(workflow_runs)`)
     if (!columns.some((column) => column.name === 'wake_at')) {
       this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN wake_at INTEGER`)
+    }
+
+
+    // 0.6.0 shipped workflow_schedules with a NOT NULL interval_ms and no cron
+    // column. Adding cron alone is not enough: a cron schedule leaves
+    // interval_ms null, which that constraint rejects. SQLite cannot drop a NOT
+    // NULL in place, so the table is rebuilt — cheap, since schedules are few.
+    const scheduleColumns = this.all<{ name: string }>(`PRAGMA table_info(workflow_schedules)`)
+    if (scheduleColumns.length > 0 && !scheduleColumns.some((column) => column.name === 'cron')) {
+      this.db.exec(`
+        ALTER TABLE workflow_schedules RENAME TO workflow_schedules_old;
+
+        CREATE TABLE workflow_schedules (
+          key          TEXT PRIMARY KEY,
+          workflow     TEXT NOT NULL,
+          input        TEXT NOT NULL,
+          interval_ms  INTEGER,
+          cron         TEXT,
+          next_run_at  INTEGER NOT NULL,
+          created_at   INTEGER NOT NULL,
+          updated_at   INTEGER NOT NULL
+        );
+
+        INSERT INTO workflow_schedules (key, workflow, input, interval_ms, cron, next_run_at, created_at, updated_at)
+        SELECT key, workflow, input, interval_ms, NULL, next_run_at, created_at, updated_at
+        FROM workflow_schedules_old;
+
+        DROP TABLE workflow_schedules_old;
+      `)
     }
 
     this.db.exec(`
@@ -524,20 +556,26 @@ export class SQLiteStorage implements StorageAdapter {
   async upsertSchedule(schedule: WorkflowSchedule): Promise<WorkflowSchedule> {
     return this.transaction(() => {
       this.run(
-        `INSERT INTO workflow_schedules (key, workflow, input, interval_ms, next_run_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO workflow_schedules (key, workflow, input, interval_ms, cron, next_run_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(key) DO UPDATE SET
            workflow    = excluded.workflow,
            input       = excluded.input,
            interval_ms = excluded.interval_ms,
-           next_run_at = CASE WHEN workflow_schedules.interval_ms = excluded.interval_ms
+           cron        = excluded.cron,
+           -- Keep the existing cadence unless the recurrence itself changed, so
+           -- a redeploy does not push the next firing out every time. IS rather
+           -- than = so a NULL on either side compares correctly.
+           next_run_at = CASE WHEN workflow_schedules.interval_ms IS excluded.interval_ms
+                               AND workflow_schedules.cron IS excluded.cron
                               THEN workflow_schedules.next_run_at
                               ELSE excluded.next_run_at END,
            updated_at  = excluded.updated_at`,
         schedule.key,
         schedule.workflow,
         serializePersistedValue(schedule.input, 'Schedule input'),
-        schedule.intervalMs,
+        schedule.recurrence.kind === 'interval' ? schedule.recurrence.intervalMs : null,
+        schedule.recurrence.kind === 'cron' ? schedule.recurrence.expression : null,
         schedule.nextRunAt,
         schedule.createdAt,
         schedule.updatedAt,
@@ -581,7 +619,7 @@ export class SQLiteStorage implements StorageAdapter {
 
       const changes = this.run(
         `UPDATE workflow_schedules SET next_run_at = ?, updated_at = ? WHERE key = ? AND next_run_at = ?`,
-        nextOccurrence(row.next_run_at, row.interval_ms, now),
+        nextOccurrence(row.next_run_at, rowRecurrence(row), now),
         now,
         row.key,
         row.next_run_at,
@@ -675,12 +713,19 @@ function isUniqueConstraintError(error: unknown): boolean {
     || error.message.includes('UNIQUE constraint failed')
 }
 
+/** The recurrence a schedule row describes: `cron` when set, otherwise the interval. */
+function rowRecurrence(row: WorkflowScheduleRow): ScheduleRecurrence {
+  return row.cron !== null
+    ? { kind: 'cron', expression: row.cron }
+    : { kind: 'interval', intervalMs: row.interval_ms ?? 0 }
+}
+
 function mapWorkflowScheduleRow(row: WorkflowScheduleRow): WorkflowSchedule {
   return {
     key: row.key,
     workflow: row.workflow,
     input: deserializePersistedValue(row.input),
-    intervalMs: row.interval_ms,
+    recurrence: rowRecurrence(row),
     nextRunAt: row.next_run_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/storage/sqlite-node.ts
+++ b/src/storage/sqlite-node.ts
@@ -10,6 +10,7 @@ import type {
   StorageAdapter,
   WorkflowRun,
   WorkflowSchedule,
+  ScheduleRecurrence,
 } from '../core/types'
 import { deserializePersistedValue, serializePersistedValue } from './codec'
 import { nextOccurrence } from '../core/schedule-timing'
@@ -41,7 +42,8 @@ interface WorkflowScheduleRow {
   key: string
   workflow: string
   input: string
-  interval_ms: number
+  interval_ms: number | null
+  cron: string | null
   next_run_at: number
   created_at: number
   updated_at: number
@@ -105,7 +107,8 @@ export class SQLiteStorage implements StorageAdapter {
         key          TEXT PRIMARY KEY,
         workflow     TEXT NOT NULL,
         input        TEXT NOT NULL,
-        interval_ms  INTEGER NOT NULL,
+        interval_ms  INTEGER,
+        cron         TEXT,
         next_run_at  INTEGER NOT NULL,
         created_at   INTEGER NOT NULL,
         updated_at   INTEGER NOT NULL
@@ -116,6 +119,35 @@ export class SQLiteStorage implements StorageAdapter {
     const columns = this.db.prepare(`PRAGMA table_info(workflow_runs)`).all() as { name: string }[]
     if (!columns.some((column) => column.name === 'wake_at')) {
       this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN wake_at INTEGER`)
+    }
+
+
+    // 0.6.0 shipped workflow_schedules with a NOT NULL interval_ms and no cron
+    // column. Adding cron alone is not enough: a cron schedule leaves
+    // interval_ms null, which that constraint rejects. SQLite cannot drop a NOT
+    // NULL in place, so the table is rebuilt — cheap, since schedules are few.
+    const scheduleColumns = this.db.prepare(`PRAGMA table_info(workflow_schedules)`).all() as { name: string }[]
+    if (scheduleColumns.length > 0 && !scheduleColumns.some((column) => column.name === 'cron')) {
+      this.db.exec(`
+        ALTER TABLE workflow_schedules RENAME TO workflow_schedules_old;
+
+        CREATE TABLE workflow_schedules (
+          key          TEXT PRIMARY KEY,
+          workflow     TEXT NOT NULL,
+          input        TEXT NOT NULL,
+          interval_ms  INTEGER,
+          cron         TEXT,
+          next_run_at  INTEGER NOT NULL,
+          created_at   INTEGER NOT NULL,
+          updated_at   INTEGER NOT NULL
+        );
+
+        INSERT INTO workflow_schedules (key, workflow, input, interval_ms, cron, next_run_at, created_at, updated_at)
+        SELECT key, workflow, input, interval_ms, NULL, next_run_at, created_at, updated_at
+        FROM workflow_schedules_old;
+
+        DROP TABLE workflow_schedules_old;
+      `)
     }
 
     this.db.exec(`
@@ -501,20 +533,26 @@ export class SQLiteStorage implements StorageAdapter {
    */
   async upsertSchedule(schedule: WorkflowSchedule): Promise<WorkflowSchedule> {
     const upsert = this.db.transaction(() => {
-      this.db.prepare(`INSERT INTO workflow_schedules (key, workflow, input, interval_ms, next_run_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+      this.db.prepare(`INSERT INTO workflow_schedules (key, workflow, input, interval_ms, cron, next_run_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(key) DO UPDATE SET
            workflow    = excluded.workflow,
            input       = excluded.input,
            interval_ms = excluded.interval_ms,
-           next_run_at = CASE WHEN workflow_schedules.interval_ms = excluded.interval_ms
+           cron        = excluded.cron,
+           -- Keep the existing cadence unless the recurrence itself changed, so
+           -- a redeploy does not push the next firing out every time. IS rather
+           -- than = so a NULL on either side compares correctly.
+           next_run_at = CASE WHEN workflow_schedules.interval_ms IS excluded.interval_ms
+                               AND workflow_schedules.cron IS excluded.cron
                               THEN workflow_schedules.next_run_at
                               ELSE excluded.next_run_at END,
            updated_at  = excluded.updated_at`).run(
         schedule.key,
         schedule.workflow,
         serializePersistedValue(schedule.input, 'Schedule input'),
-        schedule.intervalMs,
+        schedule.recurrence.kind === 'interval' ? schedule.recurrence.intervalMs : null,
+        schedule.recurrence.kind === 'cron' ? schedule.recurrence.expression : null,
         schedule.nextRunAt,
         schedule.createdAt,
         schedule.updatedAt,
@@ -553,7 +591,7 @@ export class SQLiteStorage implements StorageAdapter {
 
       const result = this.db
         .prepare(`UPDATE workflow_schedules SET next_run_at = ?, updated_at = ? WHERE key = ? AND next_run_at = ?`)
-        .run(nextOccurrence(row.next_run_at, row.interval_ms, now), now, row.key, row.next_run_at)
+        .run(nextOccurrence(row.next_run_at, rowRecurrence(row), now), now, row.key, row.next_run_at)
 
       // Guarded on the slot we read, so a racing claim cannot fire it twice.
       if (result.changes === 0) {
@@ -607,12 +645,19 @@ function isUniqueConstraintError(error: unknown): boolean {
     || error.message.includes('UNIQUE constraint failed')
 }
 
+/** The recurrence a schedule row describes: `cron` when set, otherwise the interval. */
+function rowRecurrence(row: WorkflowScheduleRow): ScheduleRecurrence {
+  return row.cron !== null
+    ? { kind: 'cron', expression: row.cron }
+    : { kind: 'interval', intervalMs: row.interval_ms ?? 0 }
+}
+
 function mapWorkflowScheduleRow(row: WorkflowScheduleRow): WorkflowSchedule {
   return {
     key: row.key,
     workflow: row.workflow,
     input: deserializePersistedValue(row.input),
-    intervalMs: row.interval_ms,
+    recurrence: rowRecurrence(row),
     nextRunAt: row.next_run_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/website/api/engine.md
+++ b/website/api/engine.md
@@ -48,9 +48,11 @@ await engine.sendEvent(run.id, 'approved', { approver: 'alice' })
 
 Delivery is durable and order-independent: an event sent before the run reaches the wait is buffered and consumed when it gets there. Returns `false` if the run does not exist or has already finished (completed / failed / cancelled); throws [`ConfigError`](/api/errors) if the workflow has no such event step, or [`ValidationError`](/api/errors) if the payload fails the wait's schema. See [Waiting for Events](/guide/wait-for-event).
 
-## `engine.schedule(name, input, intervalMs, options?)`
+## `engine.schedule(name, input, recurrence, options?)`
 
-Registers a durable recurring schedule. Returns `Promise<string>` resolving to its key. Validates `name` and `input` immediately.
+Registers a durable recurring schedule. Returns `Promise<string>` resolving to its key. Validates `name`, `input`, and the recurrence immediately.
+
+`recurrence` is a number of milliseconds, `{ every }` (milliseconds or a duration string like `'1h'`), or `{ cron }` (a five-field expression, evaluated in **UTC**). A malformed or unsatisfiable cron expression throws `ConfigError` here rather than on the first tick.
 
 The schedule is persisted rather than held as an in-process timer, so it survives restarts; registering the same key again updates it in place, preserving the cadence unless the interval changed. Due firings are claimed atomically, so N instances sharing a schedule produce one run per interval. `options.key` sets the identity explicitly (it otherwise defaults to a hash of the name, interval, and input). See [Scheduled Workflows](/guide/scheduling).
 

--- a/website/api/types.md
+++ b/website/api/types.md
@@ -27,7 +27,9 @@ type StepStatus =
 | `StepResult` | `{ id, runId, name, status, output, error, attempts, createdAt, updatedAt }` |
 | `RunInfo` | `{ run: WorkflowRun; steps: StepResult[] }` — returned by `getRunStatus()` |
 | `CreateRunResult` | `{ run: WorkflowRun; created: boolean }` — returned by `storage.createRun()` |
-| `WorkflowSchedule` | `{ key, workflow, input, intervalMs, nextRunAt, createdAt, updatedAt }` — a registered [schedule](/guide/scheduling) |
+| `WorkflowSchedule` | `{ key, workflow, input, recurrence, nextRunAt, createdAt, updatedAt }` — a registered [schedule](/guide/scheduling) |
+| `ScheduleRecurrence` | `{ kind: 'interval'; intervalMs }` \| `{ kind: 'cron'; expression }` — how a schedule repeats |
+| `ScheduleSpec` | What `engine.schedule()` accepts: `number` \| `{ every }` \| `{ cron }` |
 | `RetryConfig` | `{ maxAttempts, backoff, initialDelayMs?, timeoutMs? }` |
 
 ## Workflow & engine types

--- a/website/guide/scheduling.md
+++ b/website/guide/scheduling.md
@@ -10,7 +10,49 @@ const key = await engine.schedule('cleanup', { olderThanDays: 30 }, 60 * 60 * 10
 await engine.unschedule(key)
 ```
 
-`schedule(name, input, intervalMs, options?)` validates the input, stores the schedule, and returns its key. Each firing is a normal `enqueue()`, so everything else applies: type-safety on the name and input, durability, retries, hooks.
+`schedule(name, input, recurrence, options?)` validates the input, stores the schedule, and returns its key. Each firing is a normal `enqueue()`, so everything else applies: type-safety on the name and input, durability, retries, hooks.
+
+## Intervals and cron
+
+The recurrence is either a fixed gap or a cron expression:
+
+```typescript
+await engine.schedule('cleanup', input, 60 * 60 * 1000)   // every hour, in ms
+await engine.schedule('cleanup', input, { every: '1h' })  // same, as a duration
+await engine.schedule('report',  input, { cron: '0 9 * * 1-5' })  // 09:00, weekdays
+```
+
+`{ every }` takes milliseconds or a unit-suffixed string (`'500ms'`, `'30s'`, `'24h'`, `'7d'`) — the same form [`.sleep()`](/guide/sleep) accepts. A bare number is milliseconds.
+
+`{ cron }` takes the standard five fields — `minute hour day-of-month month day-of-week` — with wildcards, ranges, lists, a `/step` suffix, three-letter month and day names, and the `@hourly` / `@daily` / `@weekly` / `@monthly` / `@yearly` aliases:
+
+| Expression | Fires |
+|---|---|
+| `*/15 * * * *` | every 15 minutes |
+| `0 * * * *` | hourly, on the hour |
+| `0 9 * * 1-5` | 09:00, Monday to Friday |
+| `30 2 1 * *` | 02:30 on the 1st of each month |
+| `0 0 * * SUN` | midnight on Sundays |
+| `@daily` | midnight |
+
+A malformed expression is rejected by `schedule()` rather than on the first tick — registration is the last point a bad cadence can reach you, since after that the schedule fires unattended. So is an expression that can never occur, like `0 0 30 2 *` (the 30th of February).
+
+Cron inherits one quirk worth knowing: when **both** day-of-month and day-of-week are narrowed, they are OR'd, not AND'd. `0 0 13 * 5` means "the 13th, and also every Friday" — not "Friday the 13th".
+
+::: warning Cron expressions are evaluated in UTC
+There is no time-zone option. Interpreting cron in a local zone means deciding what a schedule means during a DST gap (a wall-clock time that doesn't occur) and a DST overlap (one that occurs twice), and guessing there produces a scheduler that silently skips or doubles a run twice a year. UTC has no such ambiguity.
+
+If you need a local-time schedule, convert the intended local time to UTC yourself and accept that it shifts by an hour across DST — or use an interval, which is unaffected.
+:::
+
+You can check an expression, or preview its occurrences, without registering anything:
+
+```typescript
+import { parseCron, nextCronOccurrence } from 'reflow-ts'
+
+const cron = parseCron('0 9 * * 1-5')       // throws ConfigError if malformed
+new Date(nextCronOccurrence(cron, Date.now()))
+```
 
 ## Schedules are stored, not held in memory
 
@@ -24,7 +66,7 @@ await engine.start()
 await engine.schedule('cleanup', { olderThanDays: 30 }, 60 * 60 * 1000)
 ```
 
-Re-registering **preserves the existing cadence** unless the interval itself changed. Without that, a service that redeploys more often than its schedule fires would reset the clock every time and the schedule would never run.
+Re-registering **preserves the existing cadence** unless the recurrence itself changed. Without that, a service that redeploys more often than its schedule fires would reset the clock every time and the schedule would never run.
 
 ## Running on more than one engine
 
@@ -65,6 +107,8 @@ for (const schedule of await engine.listSchedules()) {
 If every instance is down for three hours on an hourly schedule, it fires **once** when the fleet returns and then resumes its normal cadence. Backfilling three runs at once turns an outage into a thundering herd, which is almost never what a recurring job wants.
 
 If you need every missed period processed, make that explicit in the workflow — pass a window and have the first step work out what it still owes — rather than relying on the scheduler to replay.
+
+The same applies to cron: a `0 9 * * *` schedule that was down for three days fires once on return, at the next 09:00, not three times.
 
 ::: tip At most once per occurrence
 A firing is claimed and advanced before the run is enqueued, so a process that dies in the moment between the two skips that occurrence rather than repeating it. Schedules are a trigger, not a ledger: if a period must never be missed, record the work itself durably and let the schedule drive a reconciliation step.


### PR DESCRIPTION
```typescript
await engine.schedule('report', input, { cron: '0 9 * * 1-5' })  // 09:00 weekdays
await engine.schedule('cleanup', input, { every: '1h' })         // duration string
await engine.schedule('sweep', input, 60_000)                    // still works
```

This is what the stored `nextRunAt` from #71 was for. Wall-clock interval arithmetic cannot express a cadence whose gaps vary — "weekdays at 09:00" jumps three days across a weekend — but a stored next-occurrence can.

## The parser

Written from scratch, so the package keeps its **single runtime dependency**. Standard five fields, with wildcards, ranges, lists, a `/step` suffix, three-letter month and day names, and the `@hourly`…`@yearly` aliases.

It implements cron's oldest quirk deliberately: when **both** day-of-month and day-of-week are narrowed they are OR'd, not AND'd, so `0 0 13 * 5` means "the 13th, and also every Friday". The test for it uses April 2026, where the 3rd is a Friday well before the 13th — a Friday-the-13th month would pass either way and prove nothing.

Occurrence search walks whole days rather than minutes, so `0 0 1 1 *` costs a few hundred iterations instead of half a million, and it bounds itself on a wall-clock deadline rather than an iteration counter, so it provably terminates instead of looping forever on `0 0 30 2 *`.

## UTC, deliberately

There is no time-zone option. Interpreting cron in a local zone means deciding what a schedule means during a DST **gap** (a wall-clock time that doesn't occur) and a DST **overlap** (one that occurs twice). Guessing there produces a scheduler that silently skips or doubles a run twice a year — worse than not offering it. The constraint is documented prominently rather than buried.

## Failing early

Malformed *and* unsatisfiable expressions are rejected by `schedule()`, not on the first tick. Registration is the last point a bad cadence can reach the caller; after that the schedule fires unattended.

## Breaking

`WorkflowSchedule.intervalMs` becomes `recurrence` — a tagged union of `{ kind: 'interval' }` / `{ kind: 'cron' }`, so a schedule can't be stored with both or neither. Affects `listSchedules()` readers and custom adapter authors; `StorageAdapter` method signatures are unchanged.

## The migration matters here

0.6.0 is **published**, so real databases have `workflow_schedules` with `interval_ms INTEGER NOT NULL` — which a cron row cannot satisfy, and SQLite cannot drop a `NOT NULL` in place. `initialize()` rebuilds the table when it finds the old shape, preserving rows. Tested against a genuine 0.6-shaped table, and asserted idempotent. **No manual migration needed.**

## Verification

**692 tests** (33 dedicated to the parser). All four adapters held to five new conformance cases — including that a claimed cron schedule advances to its *next occurrence* rather than by a fixed gap — so Bun now runs 47 contract cases. Typecheck, coverage gate, build, docs build, and `syncpack` clean.

I independently verified the date facts every parser expectation depends on (weekdays, leap years, month lengths) rather than trusting that a passing test encodes a correct expectation.