### PR TITLE
docs: pair the right better-sqlite3 major with each Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ npm install reflow-ts better-sqlite3
 
 Node.js 18.18 or newer is required.
 
+**On Node 18–21, pin `better-sqlite3@12`** — version 13 raises its own floor to Node 22, so the
+plain install above fails there with an engine error. Reflow accepts `better-sqlite3 >= 9`, so
+`npm install reflow-ts better-sqlite3@12` works on any supported Node. On Node 22+, the latest is
+fine. This applies only to the `reflow-ts/sqlite-node` adapter; Bun and the `node:sqlite` adapter
+have no native dependency.
+
 Then pick a storage adapter based on your runtime:
 
 ```typescript

--- a/website/guide/install.md
+++ b/website/guide/install.md
@@ -35,6 +35,19 @@ const storage = new SQLiteStorage('./reflow.db')
 
 On Node, `better-sqlite3` is an optional peer dependency — install it alongside Reflow. On Bun, nothing extra is needed.
 
+::: warning better-sqlite3 13 requires Node 22
+Reflow supports Node 18.18+, but `better-sqlite3` 13 raises its own floor to Node 22, so a plain `npm install better-sqlite3` fails on Node 18–21 with an engine error.
+
+Reflow's peer range is `>=9`, so pin the older major there:
+
+```bash
+npm install reflow-ts better-sqlite3@12   # Node 18-21
+npm install reflow-ts better-sqlite3      # Node 22+
+```
+
+Only the `reflow-ts/sqlite-node` adapter is affected. Bun's adapter and the `node:sqlite` adapter have no native dependency — though the latter needs Node 22.5+ for its own reasons.
+:::
+
 See [Storage](/guide/storage) for the in-memory adapter and how to write your own.
 
 ## Pick a schema library


### PR DESCRIPTION
Surfaced by the better-sqlite3 13 bump in #80, not reported by anyone — nothing in the test suite covers what a consumer's install actually resolves to.

## The problem

better-sqlite3 13 raises its own floor to `node: >=22` (12.10.0 allowed 20.x+). Our install instructions say:

```bash
npm install reflow-ts better-sqlite3
```

immediately followed by "Node.js 18.18 or newer is required". On Node 18–21 that command now resolves to 13 and fails with an engine error — the docs contradict themselves for anyone on our own stated minimum.

## The fix

Reflow's peer range is `>=9`, so the escape hatch already exists; it just wasn't discoverable. Both the README and the install guide now say to pin `better-sqlite3@12` on Node 18–21, and scope it — only the `sqlite-node` adapter has a native dependency at all. Bun's is built in, and the `node:sqlite` adapter has none (though it needs Node 22.5+ for its own reasons).

Docs only; no code change.